### PR TITLE
Remove inline javascript

### DIFF
--- a/src/main/resources/io/jenkins/plugins/explain_error/ConsolePageDecorator/footer.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/ConsolePageDecorator/footer.jelly
@@ -17,13 +17,13 @@
             <p>An AI explanation was already generated on <span id="existing-explanation-timestamp"></span>.</p>
             <p>Do you want to view the existing explanation or generate a new one?</p>
             <div class="jenkins-button-bar">
-              <button type="button" class="jenkins-button jenkins-button--primary jenkins-!-margin-1" onclick="viewExistingExplanation()">
+              <button type="button" class="jenkins-button jenkins-button--primary jenkins-!-margin-1 eep-view-existing-button" onclick="viewExistingExplanation()">
                 View Existing
               </button>
-              <button type="button" class="jenkins-button jenkins-!-margin-1" onclick="generateNewExplanation()">
+              <button type="button" class="jenkins-button jenkins-!-margin-1 eep-generate-new-button">
                 Generate New
               </button>
-              <button type="button" class="jenkins-button jenkins-!-margin-1" onclick="cancelExplanation()">
+              <button type="button" class="jenkins-button jenkins-!-margin-1 eep-cancel-button" onclick="cancelExplanation()">
                 Cancel
               </button>
             </div>

--- a/src/main/webapp/js/explain-error-footer.js
+++ b/src/main/webapp/js/explain-error-footer.js
@@ -180,16 +180,29 @@ function showConfirmationDialog(timestamp) {
   hideContainer();
 }
 
+Behaviour.specify(".eep-view-existing-button", "ExplainErrorView", 0, function(e) {
+  e.onclick = viewExistingExplanation;
+});
+
+
 function viewExistingExplanation() {
   hideConfirmationDialog();
   sendExplainRequest(false); // This will return the cached result
 }
+
+Behaviour.specify(".eep-generate-new-button", "ExplainErrorView", 0, function(e) {
+  e.onclick = generateNewExplanation;
+});
 
 function generateNewExplanation() {
   hideConfirmationDialog();
   clearExplanationContent();
   sendExplainRequest(true); // Force new explanation
 }
+
+Behaviour.specify(".eep-cancel-button", "ExplainErrorView", 0, function(e) {
+  e.onclick = cancelExplanation;
+});
 
 function cancelExplanation() {
   hideConfirmationDialog();


### PR DESCRIPTION
Do not use inline javascript as this is a problem when applying stricter CSP rules

fixes #49

<!-- Please describe your pull request here. -->

### Testing done
Interactively tested that the buttons work with strict CSP rules and no more

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
