### PR TITLE
Make pipeline-graph-view a required dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
       <artifactId>commons-lang3-api</artifactId>
     </dependency>
 
-    <!-- Required dependency for pipeline log extraction and error analysis -->
+    <!-- Required for link error to pipeline graph view -->
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>pipeline-graph-view</artifactId>


### PR DESCRIPTION
Fixup of #81 

Removed `optional=true` from `pipeline-graph-view` dependency to ensure it is always installed with explain-error plugin.

Note: Users who need pipeline-graph-view version 777.vdeb_113b_b_94da_ or
higher can manually upgrade it, but it requires Jenkins 2.534+.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
