### PR TITLE
fix: add STS dependency for IRSA credential resolution in EKS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,5 +224,14 @@
       </exclusions>
     </dependency>
 
+    <!-- Required for IRSA (IAM Roles for Service Accounts) in EKS environments.
+         Without this, DefaultCredentialsProvider cannot perform AssumeRoleWithWebIdentity
+         and falls back to EC2 instance metadata (node role). -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <version>2.33.5</version>
+    </dependency>
+
   </dependencies>
 </project>


### PR DESCRIPTION
## Environment
- Jenkins Version: 2.479.3 (production EKS deployment)
- Plugin Version: latest main (post PR #95 merge)
- Java Version: 17
- Infrastructure: AWS EKS with IRSA (IAM Roles for Service Accounts)

## Steps to Reproduce
1. Deploy Jenkins on AWS EKS with IRSA configured for the Jenkins pod's service account
2. Install the plugin and configure the Bedrock provider
3. Click "Test Configuration" or trigger `explainError()` on a failed build
4. The plugin uses the **EKS node role** instead of the pod's service account IAM role

## Expected Behavior
The plugin should use the pod's IRSA credentials (via `AssumeRoleWithWebIdentity`) to authenticate with AWS Bedrock, inheriting the IAM role associated with the Kubernetes service account.

## Actual Behavior
```
User: arn:aws:sts::ACCOUNT:assumed-role/prod-eks-node/i-XXXXX is not authorized to perform:
bedrock:InvokeModel on resource: arn:aws:bedrock:eu-west-1:ACCOUNT:inference-profile/eu.anthropic.claude-3-5-sonnet-20240620-v1:0
because no identity-based policy allows the bedrock:InvokeModel action
(Service: BedrockRuntime, Status Code: 403)
```

The `assumed-role/prod-eks-node` in the error shows the plugin is using the EC2 instance metadata (node role) instead of the IRSA credentials.

## Root Cause
The `langchain4j-bedrock` module pulls in `software.amazon.awssdk:bedrockruntime` but **not** `software.amazon.awssdk:sts`. The AWS SDK v2 `DefaultCredentialsProvider` requires the `sts` module on the classpath to use `StsAssumeRoleWithWebIdentityCredentialsProvider`. Without it, the IRSA credential provider is silently skipped and the chain falls through to EC2 instance metadata.

## Fix
Add `software.amazon.awssdk:sts` as an explicit dependency, matching the version pulled transitively by langchain4j-bedrock (2.33.5).

## Logs
```
Configuration test failed: API request failed: User: arn:aws:sts::ACCOUNT:assumed-role/prod-eks-node/i-XXXXX
is not authorized to perform: bedrock:InvokeModel on resource:
arn:aws:bedrock:eu-west-1:ACCOUNT:inference-profile/eu.anthropic.claude-3-5-sonnet-20240620-v1:0
because no identity-based policy allows the bedrock:InvokeModel action
(Service: BedrockRuntime, Status Code: 403, Request ID: XXXXX) (SDK Attempt Count: 1)
```