### PR TITLE
fix: exclude apache-client/netty from AWS SDK deps to prevent NoClassDefFoundError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,16 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <!-- Exclude AWS SDK HTTP clients pulled in transitively via bedrockruntime.
+             See sts exclusion below for full explanation. -->
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>apache-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>netty-nio-client</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -236,6 +246,31 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
+      <version>2.33.5</version>
+      <exclusions>
+        <!-- apache-client and netty-nio-client are pulled in transitively by sts but their
+             runtime dependencies (org.apache.httpcomponents:httpclient, Netty) are not
+             bundled in the HPI and are not guaranteed to be available in the Jenkins
+             classloader. This causes NoClassDefFoundError for HttpRoutePlanner at runtime
+             unless the apache-httpcomponents-client-4-api Jenkins plugin is also installed.
+             Use url-connection-client (JDK built-in HttpURLConnection) instead — no
+             external dependencies, fully compatible with Jenkins classloading. -->
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>apache-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>netty-nio-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Explicit sync HTTP client for the AWS SDK v2. Uses JDK HttpURLConnection —
+         no external dependencies, works without additional Jenkins plugins. -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>url-connection-client</artifactId>
       <version>2.33.5</version>
     </dependency>
 


### PR DESCRIPTION
## Summary

Fixes #100 (reported in https://github.com/jenkinsci/explain-error-plugin/issues/100#issuecomment-3934798411).

### Root cause

`software.amazon.awssdk:sts` (added in #98) and `langchain4j-bedrock` (via `bedrockruntime`) both pull in `apache-client` and `netty-nio-client` as transitive **runtime** dependencies. These JARs get bundled in the HPI and register their implementations via Java ServiceLoader:

- `apache-client` → registers `ApacheSdkHttpService`
- `netty-nio-client` → registers `NettyNioAsyncHttpService`

When `BedrockProvider.createAssistant()` calls `BedrockChatModel.builder().build()`, the AWS SDK discovers `ApacheSdkHttpService` via ServiceLoader and tries to instantiate it. At line 29 of `ApacheSdkHttpService`, it requires `org.apache.httpcomponents:httpclient` — but this JAR is **not bundled in the HPI**.

`httpclient` only enters the dependency tree through `org.jenkins-ci.plugins:apache-httpcomponents-client-4-api`, which is declared as `test` scope in the pom. In a running Jenkins instance, it would only be available if that Jenkins plugin is installed — which `explain-error` does not declare as a required dependency.

```
NoClassDefFoundError: org/apache/http/conn/routing/HttpRoutePlanner
  at ApacheSdkHttpService.createHttpClientBuilder(ApacheSdkHttpService.java:29)
  ...
  at BedrockProvider.createAssistant(BedrockProvider.java:56)
```

### Fix

Exclude `apache-client` and `netty-nio-client` from both `sts` and `langchain4j-bedrock`, and explicitly add `url-connection-client`. This client uses the JDK's built-in `HttpURLConnection` — no external dependencies, works in any Jenkins environment without additional plugins.

**Dependency tree before:**
```
software.amazon.awssdk:sts
  ├── apache-client:runtime       ← bundled in HPI, triggers error
  └── netty-nio-client:runtime    ← bundled in HPI, unnecessary

langchain4j-bedrock → bedrockruntime
  ├── apache-client:runtime       ← bundled in HPI, triggers error
  └── netty-nio-client:runtime    ← bundled in HPI, unnecessary
```

**Dependency tree after:**
```
software.amazon.awssdk:url-connection-client:compile  ← bundled, no ext. deps
```

## Test plan

- [ ] Build the plugin locally (`mvn package -DskipTests`) and deploy to a Jenkins instance without `apache-httpcomponents-client-4-api` plugin installed
- [ ] Configure the Bedrock provider (Manage Jenkins → Configure System → Explain Error Plugin)
- [ ] Click "Test Configuration" — should succeed without `NoClassDefFoundError`
- [ ] Trigger a build failure and click "Explain Error" — should return an AI explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)