### PR TITLE
feat: replace cube icon with sparkles for AI Error Explanation action

### DIFF
--- a/src/main/java/io/jenkins/plugins/explain_error/ErrorExplanationAction.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ErrorExplanationAction.java
@@ -32,7 +32,7 @@ public class ErrorExplanationAction implements RunAction2 {
 
     @Override
     public String getIconFileName() {
-        return "symbol-cube";
+        return "symbol-sparkles-outline plugin-ionicons-api";
     }
 
     @Override

--- a/src/test/java/io/jenkins/plugins/explain_error/ErrorExplanationActionTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ErrorExplanationActionTest.java
@@ -34,7 +34,7 @@ class ErrorExplanationActionTest {
 
     @Test
     void testGetIconFileName() {
-        assertEquals("symbol-cube", action.getIconFileName());
+        assertEquals("symbol-sparkles-outline plugin-ionicons-api", action.getIconFileName());
     }
 
     @Test


### PR DESCRIPTION
symbol-cube is generic and carries no semantic meaning. 
symbol-sparkles-outline (ionicons) is the de-facto standard icon for AI-powered features (used by GitHub Copilot, ChatGPT, etc.) and immediately signals to users that the result was produced by AI.

symbol-sparkles-outline: https://github.com/jenkinsci/ionicons-api-plugin/blob/main/src/main/resources/images/symbols/sparkles-outline.svg

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
