### PR TITLE
docs: bump Jenkins baseline to 2.528.3 and LangChain4j to 1.11.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,7 +66,7 @@ src/main/java/io/jenkins/plugins/explain_error/
 
 ### AI Service Integration
 - All AI services extend `BaseAIProvider` and implement `ExtensionPoint`
-- LangChain4j integration (v1.9.1) for OpenAI, Gemini, AWS Bedrock, and Ollama providers
+- LangChain4j integration (v1.11.0) for OpenAI, Gemini, AWS Bedrock, and Ollama providers
 - Structured output parsing using `JenkinsLogAnalysis` record with `@Description` annotations
 - Each provider implements `createAssistant()` to build LangChain4j assistants
 - Provider descriptors extend `BaseProviderDescriptor` with `@Symbol` annotations for CasC
@@ -123,9 +123,9 @@ Use `provider.setThrowError(true)` to simulate failures, `provider.getLastCustom
 ## Build & Dependencies
 
 ### Maven Configuration
-- Jenkins baseline: 2.479.3
+- Jenkins baseline: 2.528.3
 - Java 17+ required
-- LangChain4j: v1.9.1 (langchain4j, langchain4j-open-ai, langchain4j-google-ai-gemini, langchain4j-bedrock, langchain4j-ollama)
+- LangChain4j: v1.11.0 (langchain4j, langchain4j-open-ai, langchain4j-google-ai-gemini, langchain4j-bedrock, langchain4j-ollama)
 - Key Jenkins dependencies: `jackson2-api`, `workflow-step-api`, `commons-lang3-api`
 - SLF4J and Jackson exclusions to avoid conflicts with Jenkins core
 - Test dependencies: `workflow-cps`, `workflow-job`, `workflow-durable-task-step`, `workflow-basic-steps`, `test-harness`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This guide will help you get started with development and contribution.
 
 - **Java**: Version 17 or later
 - **Maven**: Version 3.9 or later
-- **Jenkins**: Version 2.479.3 or later for testing
+- **Jenkins**: Version 2.528.3 or later for testing
 - **Git**: For version control
 - **IDE**: IntelliJ IDEA or VS Code recommended
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Works with Freestyle, Declarative, or any job type.
 |-------|----------|
 |API key not set	| Add your key in Jenkins global config |
 |Auth or rate limit error| Check key validity, quota, and provider plan |
-|Button not visible	| Ensure Jenkins version ≥ 2.479.3, restart Jenkins after installation |
+|Button not visible	| Ensure Jenkins version ≥ 2.528.3, restart Jenkins after installation |
 
 Enable debug logs:
 


### PR DESCRIPTION
bump Jenkins baseline to 2.528.3 and LangChain4j to 1.11.0, because they are out of date.
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
