### PR TITLE
Fix NullPointerException when AiProvider is null

### DIFF
--- a/src/main/java/io/jenkins/plugins/explain_error/ConsolePageDecorator.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ConsolePageDecorator.java
@@ -24,10 +24,17 @@ public class ConsolePageDecorator extends PageDecorator {
             return false;
         }
 
+        if (config.getAiProvider() == null) {
+            return false;
+        }
+
         return !config.getAiProvider().isNotValid(null);
     }
 
     public String getProviderName() {
+        if (GlobalConfigurationImpl.get().getAiProvider() == null) {
+            return null;
+        }
         return GlobalConfigurationImpl.get().getAiProvider().getProviderName();
     }
 

--- a/src/test/java/io/jenkins/plugins/explain_error/ConsolePageDecoratorTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ConsolePageDecoratorTest.java
@@ -57,6 +57,13 @@ class ConsolePageDecoratorTest {
     }
 
     @Test
+    void testIsExplainErrorEnabledWhenAiProviderIsNull() {
+        // Should return false (not throw NPE) when aiProvider is null
+        config.setAiProvider(null);
+        assertFalse(decorator.isExplainErrorEnabled());
+    }
+
+    @Test
     void testIsExplainErrorEnabledWithNullApiKey() {
         provider.setApiKey(null);
 


### PR DESCRIPTION
## Summary

- Guard against `null` return from `getAiProvider()` in `ConsolePageDecorator.isExplainErrorEnabled()` — was throwing NPE when no AI provider had been configured yet
- Same null guard added to `getProviderName()` for consistency
- Adds a test case `testIsExplainErrorEnabledWhenAiProviderIsNull` to cover this scenario

Fixes #125

## Test plan

- [x] Install the plugin on a fresh Jenkins instance without configuring an AI provider
- [x] Navigate to a build's console log — no NPE should appear in Jenkins logs
- [x] Run `ConsolePageDecoratorTest` — all tests should pass including the new null-provider test

https://claude.ai/code/session_01YTTwYUBFFBpbKz2yk4KAhe