### PR TITLE
Default global AI provider to OpenAI

### DIFF
--- a/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
@@ -48,10 +48,11 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
                     case GEMINI -> new GeminiProvider(apiUrl, model, apiKey);
                     case OLLAMA -> new OllamaProvider(apiUrl, model);
                 };
+                provider = null;
+                save();
             } else {
                 aiProvider = new OpenAIProvider(null, OpenAIProvider.DEFAULT_MODEL, null);
             }
-            save();
         }
         return this;
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
@@ -41,12 +41,16 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
     }
 
     public Object readResolve() {
-        if (aiProvider == null && provider != null) {
-            aiProvider = switch (provider) {
-                case OPENAI -> new OpenAIProvider(apiUrl, model, apiKey);
-                case GEMINI -> new GeminiProvider(apiUrl, model, apiKey);
-                case OLLAMA -> new OllamaProvider(apiUrl, model);
-            };
+        if (aiProvider == null) {
+            if (provider != null) {
+                aiProvider = switch (provider) {
+                    case OPENAI -> new OpenAIProvider(apiUrl, model, apiKey);
+                    case GEMINI -> new GeminiProvider(apiUrl, model, apiKey);
+                    case OLLAMA -> new OllamaProvider(apiUrl, model);
+                };
+            } else {
+                aiProvider = new OpenAIProvider(null, OpenAIProvider.DEFAULT_MODEL, null);
+            }
             save();
         }
         return this;

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAIProvider.java
@@ -25,6 +25,7 @@ import org.kohsuke.stapler.verb.POST;
 public class OpenAIProvider extends BaseAIProvider {
 
     private static final Logger LOGGER = Logger.getLogger(OpenAIProvider.class.getName());
+    public static final String DEFAULT_MODEL = "gpt-4.1";
 
     protected Secret apiKey;
 
@@ -90,7 +91,7 @@ public class OpenAIProvider extends BaseAIProvider {
         }
 
         public String getDefaultModel() {
-            return "gpt-4.1";
+            return DEFAULT_MODEL;
         }
 
         @GET

--- a/src/test/java/io/jenkins/plugins/explain_error/GlobalConfigurationImplTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/GlobalConfigurationImplTest.java
@@ -9,6 +9,10 @@ import hudson.util.Secret;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
 import io.jenkins.plugins.explain_error.provider.GeminiProvider;
 import io.jenkins.plugins.explain_error.provider.OpenAIProvider;
+import java.util.List;
+import org.htmlunit.html.HtmlOption;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlSelect;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -18,9 +22,11 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 class GlobalConfigurationImplTest {
 
     private GlobalConfigurationImpl config;
+    private JenkinsRule rule;
 
     @BeforeEach
     void setUp(JenkinsRule jenkins) {
+        rule = jenkins;
         config = GlobalConfigurationImpl.get();
 
         // Reset to clean state for each test (no auto-population)
@@ -41,6 +47,40 @@ class GlobalConfigurationImplTest {
     @Test
     void testDefaultValues() {
         assertTrue(config.isEnableExplanation());
+    }
+
+    @Test
+    void testDefaultsToOpenAiProviderWhenUnconfigured() {
+        config.setAiProvider(null);
+        config.setProvider(null);
+        config.setApiKey(null);
+        config.setApiUrl(null);
+        config.setModel(null);
+
+        BaseAIProvider provider = config.getAiProvider();
+
+        assertThat(provider, instanceOf(OpenAIProvider.class));
+        assertEquals(OpenAIProvider.DEFAULT_MODEL, provider.getModel());
+        assertNull(provider.getUrl());
+    }
+
+    @Test
+    void testConfigurePageDefaultsProviderSelectionToOpenAi() throws Exception {
+        config.setAiProvider(null);
+        config.setProvider(null);
+        config.setApiKey(null);
+        config.setApiUrl(null);
+        config.setModel(null);
+
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            client.getOptions().setJavaScriptEnabled(false);
+            HtmlPage page = client.goTo("configure");
+            HtmlSelect providerSelect = findProviderSelect(page);
+
+            List<HtmlOption> selectedOptions = providerSelect.getSelectedOptions();
+            assertEquals(1, selectedOptions.size());
+            assertEquals("OpenAI", selectedOptions.get(0).getText().trim());
+        }
     }
 
     @Test
@@ -78,5 +118,20 @@ class GlobalConfigurationImplTest {
         String displayName = config.getDisplayName();
         assertNotNull(displayName);
         assertEquals("Explain Error Plugin Configuration", displayName);
+    }
+
+    private HtmlSelect findProviderSelect(HtmlPage page) {
+        return page.getByXPath("//div[normalize-space()='AI Provider']/following::select[1]").stream()
+                .filter(HtmlSelect.class::isInstance)
+                .map(HtmlSelect.class::cast)
+                .findFirst()
+                .orElseThrow(() -> {
+                    String xml = page.asXml();
+                    int marker = xml.indexOf("Explain Error Plugin Configuration");
+                    String snippet = marker >= 0
+                            ? xml.substring(Math.max(0, marker - 500), Math.min(xml.length(), marker + 2500))
+                            : xml.substring(0, Math.min(xml.length(), 3000));
+                    return new AssertionError("AI provider dropdown not found on configure page. Snippet:\n" + snippet);
+                });
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR aligns the implementation with the documented behavior by making OpenAI the default global AI provider when no provider has been configured yet.
It also adds regression coverage to ensure both the backend default and the Jenkins configuration UI stay consistent.

The README says OpenAI is the default AI provider.
Before this change, the code had no real default provider and could end up with no provider configured.
With this fix, runtime behavior and the configuration UI now match the documented expectation.

before:
<img width="500" height="360" alt="image" src="https://github.com/user-attachments/assets/ad99a269-4ca9-4e74-97a1-4336f3435b9c" />

after:
<img width="500" height="486" alt="image" src="https://github.com/user-attachments/assets/e0b68883-6afd-490a-936d-5f752cb0b268" />


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
