### PR TITLE
Add optional usage quotas for Explain Error provider calls

### DIFF
--- a/docs/usage-quota.md
+++ b/docs/usage-quota.md
@@ -1,0 +1,140 @@
+# AI Provider Call Quotas
+
+Usage quotas let administrators cap the number of real AI provider calls the plugin makes within a rolling time window. This prevents unexpected API cost spikes and gives you predictable spend control — both at the Jenkins controller level and at the folder level.
+
+---
+
+## What Is Supported
+
+| Feature | Details |
+|---|---|
+| **Time windows** | Hourly or Daily |
+| **Controller-level quota** | One global quota covering all jobs on the Jenkins controller |
+| **Folder-level quota** | Per-folder quota that overrides the global quota for all jobs inside that folder (and its subfolders) |
+| **Quota inheritance** | Quota resolution walks up the folder hierarchy; the **nearest** folder with `Enable Request Quota` turned on wins |
+| **Configuration as Code** | Both global and folder-level quotas are expressible in CasC YAML |
+| **Usage event tracking** | Rejected calls emit a `QUOTA_REJECTED` usage event (visible in `MetricsUsageRecorder`) |
+| **Real-time config changes** | Changing the limit takes effect immediately — no Jenkins restart needed |
+| **Thread safety** | The counter is synchronized, so concurrent builds on the same controller share the same window correctly |
+
+---
+
+## What Is Not Supported
+
+| Limitation | Notes |
+|---|---|
+| **Per-user quotas** | Quota is tracked per controller / per folder, not per Jenkins user |
+| **Per-job quotas** | There is no job-level quota; the smallest scope is a folder |
+| **Quota persistence across restarts** | The in-memory counter resets when Jenkins restarts. A restart effectively begins a new window |
+| **Cache hits count toward quota** | Only real provider calls are counted. Returning an already-stored `ErrorExplanationAction` (cache hit) does **not** consume quota |
+| **More than two time windows** | Only `Hourly` and `Daily` windows are available |
+| **Alerts / notifications when quota is reached** | There is no email or notification hook; the only signal is the console message and the `QUOTA_REJECTED` usage event |
+| **Quota carry-over** | Unused capacity from the previous window does not roll over |
+
+---
+
+## How to Configure
+
+### Controller-level quota (global)
+
+1. Go to **Manage Jenkins → Configure System**.
+2. Scroll to the **Explain Error Plugin Configuration** section.
+3. Make sure **Enable AI Error Explanation** is checked.
+4. Check **Enable Request Quota**.
+5. Choose a **Quota Window** — `Hourly` or `Daily`.
+6. Set **Max Provider Calls per Window** to the maximum number of real AI calls you want to allow in that window. Setting it to `0` blocks all calls.
+7. Save.
+
+When the quota is exceeded the plugin logs the following message to the build console and records a `QUOTA_REJECTED` event:
+
+```
+[explain-error] Provider call quota exceeded. Limit: <N> calls per <window> window.
+```
+
+#### CasC example (global)
+
+```yaml
+unclassified:
+  explainError:
+    enableExplanation: true
+    aiProvider:
+      openai:
+        apiKey: "${AI_API_KEY}"
+        model: "gpt-4o"
+    enableQuota: true
+    quotaWindow: HOURLY
+    maxProviderCallsPerWindow: 50
+```
+
+---
+
+### Folder-level quota
+
+Folder-level quotas override the global quota for every job inside that folder (including nested subfolders). Use this when different teams have different cost budgets or SLA requirements.
+
+1. Open the folder you want to configure and click **Configure**.
+2. Scroll to the **Explain Error Configuration** section.
+3. Check **Enable AI Error Explanation**.
+4. Check **Enable Request Quota**.
+5. Choose a **Quota Window** and set **Max Provider Calls per Window**.
+6. Save.
+
+When the folder-level quota is exceeded, the console message is:
+
+```
+[explain-error] Provider call quota exceeded (folder level). Limit: <N> calls per <window> window.
+```
+
+#### CasC example (folder)
+
+```yaml
+jobs:
+  - script: |
+      folder('my-team') {
+        properties([
+          [$class: 'ExplainErrorFolderProperty',
+            enableExplanation: true,
+            enableQuota: true,
+            quotaWindow: 'DAILY',
+            maxProviderCallsPerWindow: 20
+          ]
+        ])
+      }
+```
+
+---
+
+## Priority / Resolution Order
+
+When a build runs, the plugin resolves the quota as follows:
+
+```
+Job's parent folder
+  └─► Does the folder have "Enable Request Quota" turned on?
+        YES → use that folder's quota (stop searching)
+        NO  → check parent folder … repeat until root
+  └─► No folder quota found → use global quota (if enabled)
+  └─► No global quota either → no limit, all calls are allowed
+```
+
+The **nearest** folder in the hierarchy **with quota enabled** wins. A folder that has the quota checkbox unchecked is skipped — the search continues upward.
+
+**Example scenario:**
+
+```
+Jenkins root  (global: 100 calls/hour)
+└── Platform  (folder quota: disabled)
+    └── Team A  (folder quota: 10 calls/day)
+        └── service-api  ← quota applied: 10 calls/day (Team A)
+    └── Team B  (no folder property at all)
+        └── service-web  ← quota applied: 100 calls/hour (global)
+```
+
+---
+
+## Tips
+
+- **Setting `maxProviderCallsPerWindow: 0`** at the global level and then using folder-level quotas is a clean way to give each team an explicit allowance while preventing any uncontrolled global spend.
+- **The window resets automatically.** After the time window elapses the counter resets on the next call — you do not need to manually clear it.
+- **Multiple builds running at the same time** share the same counter. Ten concurrent builds all count against the same window.
+- **Console action calls** (clicking the "Explain Error" button) count toward the quota in exactly the same way as `explainError()` pipeline-step calls.

--- a/src/main/java/io/jenkins/plugins/explain_error/ErrorExplainer.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ErrorExplainer.java
@@ -106,6 +106,15 @@ public class ErrorExplainer {
                 return null;
             }
 
+            // Check quota before making a real provider call (folder-level overrides global)
+            QuotaCheckResult quotaCheck = tryAcquireQuota(run);
+            if (!quotaCheck.allowed()) {
+                logToConsole(listener, quotaCheck.rejectionMessage());
+                recordUsage(entryPoint, UsageEvent.Result.QUOTA_REJECTED, provider, startTimeNanos, 0,
+                        collectDownstreamLogs);
+                return null;
+            }
+
             // Extract error logs
             logToConsole(listener, "Extracting failure logs.");
             PipelineLogExtractor.ExtractionResult extractionResult = extractErrorLogs(run, maxLines,
@@ -232,6 +241,14 @@ public class ErrorExplainer {
             throw new ExplanationException("error", "The provider is not properly configured.");
         }
 
+        // Check quota before making a real provider call (folder-level overrides global)
+        QuotaCheckResult quotaCheck = tryAcquireQuota(run);
+        if (!quotaCheck.allowed()) {
+            recordUsage(entryPoint, UsageEvent.Result.QUOTA_REJECTED, provider, startTimeNanos,
+                    inputLogLineCount, false);
+            throw new ExplanationException("warning", quotaCheck.rejectionMessage());
+        }
+
         try {
             // Get AI explanation with global custom context
             String explanation = provider.explainError(errorText, new LogTaskListener(LOGGER, Level.FINE), null,
@@ -355,6 +372,45 @@ public class ErrorExplainer {
 
     private void logToConsole(TaskListener listener, String message) {
         listener.getLogger().println(CONSOLE_PREFIX + message);
+    }
+
+    /**
+     * Attempts to acquire a quota slot. Folder-level quota (nearest ancestor with
+     * {@code enableQuota=true}) takes precedence over the global quota.
+     *
+     * @param run the current build run (may be null)
+     * @return a {@link QuotaCheckResult} indicating whether the call is allowed
+     */
+    private QuotaCheckResult tryAcquireQuota(@CheckForNull Run<?, ?> run) {
+        // Walk up the folder hierarchy to find the nearest folder-level quota
+        if (run != null) {
+            ExplainErrorFolderProperty folderQuota =
+                    ExplainErrorFolderProperty.findFolderWithQuota(run.getParent().getParent());
+            if (folderQuota != null) {
+                boolean allowed = folderQuota.tryAcquireQuota();
+                if (!allowed) {
+                    String msg = "Provider call quota exceeded (folder level). Limit: "
+                            + folderQuota.getMaxProviderCallsPerWindow()
+                            + " calls per " + folderQuota.getQuotaWindow().getDisplayName().toLowerCase()
+                            + " window.";
+                    return new QuotaCheckResult(false, msg);
+                }
+                return QuotaCheckResult.ALLOWED;
+            }
+        }
+
+        // Fall back to global quota
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        if (!config.tryAcquireQuota()) {
+            String msg = "Provider call quota exceeded. Limit: " + config.getMaxProviderCallsPerWindow()
+                    + " calls per " + config.getQuotaWindow().getDisplayName().toLowerCase() + " window.";
+            return new QuotaCheckResult(false, msg);
+        }
+        return QuotaCheckResult.ALLOWED;
+    }
+
+    private record QuotaCheckResult(boolean allowed, String rejectionMessage) {
+        static final QuotaCheckResult ALLOWED = new QuotaCheckResult(true, null);
     }
 
     private void logExtractionSummary(TaskListener listener, PipelineLogExtractor.ExtractionResult result,

--- a/src/main/java/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty.java
@@ -7,10 +7,15 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.ItemGroup;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
+import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 /**
  * Folder property for folder-level AI provider configuration.
@@ -20,6 +25,11 @@ public class ExplainErrorFolderProperty extends AbstractFolderProperty<AbstractF
 
     private BaseAIProvider aiProvider;
     private boolean enableExplanation = true;
+
+    private boolean enableQuota = false;
+    private QuotaWindow quotaWindow = QuotaWindow.HOURLY;
+    private int maxProviderCallsPerWindow = 100;
+    private transient QuotaEnforcer quotaEnforcer;
 
     @DataBoundConstructor
     public ExplainErrorFolderProperty() {
@@ -63,6 +73,76 @@ public class ExplainErrorFolderProperty extends AbstractFolderProperty<AbstractF
         if (!enableExplanation) {
             this.aiProvider = null;
         }
+    }
+
+    public boolean isEnableQuota() {
+        return enableQuota;
+    }
+
+    @DataBoundSetter
+    public void setEnableQuota(boolean enableQuota) {
+        this.enableQuota = enableQuota;
+    }
+
+    public QuotaWindow getQuotaWindow() {
+        return quotaWindow != null ? quotaWindow : QuotaWindow.HOURLY;
+    }
+
+    @DataBoundSetter
+    public void setQuotaWindow(QuotaWindow quotaWindow) {
+        this.quotaWindow = quotaWindow != null ? quotaWindow : QuotaWindow.HOURLY;
+    }
+
+    public int getMaxProviderCallsPerWindow() {
+        return maxProviderCallsPerWindow;
+    }
+
+    @DataBoundSetter
+    public void setMaxProviderCallsPerWindow(int maxProviderCallsPerWindow) {
+        this.maxProviderCallsPerWindow = Math.max(0, maxProviderCallsPerWindow);
+    }
+
+    QuotaEnforcer getQuotaEnforcer() {
+        if (quotaEnforcer == null) {
+            quotaEnforcer = new QuotaEnforcer();
+        }
+        return quotaEnforcer;
+    }
+
+    /**
+     * Attempts to acquire a quota slot for a real AI provider call.
+     *
+     * @return {@code true} if the call is allowed; {@code false} if the quota is exceeded
+     */
+    public boolean tryAcquireQuota() {
+        if (!enableQuota) {
+            return true;
+        }
+        return getQuotaEnforcer().tryAcquire(getQuotaWindow(), maxProviderCallsPerWindow);
+    }
+
+    /**
+     * Recursively search for a folder-level quota configuration.
+     * Walks up the folder hierarchy and returns the nearest folder that has
+     * {@code enableQuota=true}, or {@code null} if none is found.
+     *
+     * @param itemGroup the item group to search from
+     * @return the nearest folder property with quota enabled, or null
+     */
+    @CheckForNull
+    public static ExplainErrorFolderProperty findFolderWithQuota(@CheckForNull ItemGroup<?> itemGroup) {
+        if (itemGroup == null) {
+            return null;
+        }
+        if (itemGroup instanceof AbstractFolder) {
+            AbstractFolder<?> folder = (AbstractFolder<?>) itemGroup;
+            ExplainErrorFolderProperty property = folder.getProperties().get(ExplainErrorFolderProperty.class);
+            if (property != null && property.isEnableQuota()) {
+                return property;
+            }
+            return findFolderWithQuota(folder.getParent());
+        }
+        return null;
     }
 
     /**
@@ -143,6 +223,24 @@ public class ExplainErrorFolderProperty extends AbstractFolderProperty<AbstractF
         @Override
         public String getDisplayName() {
             return "Explain Error Configuration";
+        }
+
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
+        public ListBoxModel doFillQuotaWindowItems() {
+            ListBoxModel items = new ListBoxModel();
+            for (QuotaWindow window : QuotaWindow.values()) {
+                items.add(window.getDisplayName(), window.name());
+            }
+            return items;
+        }
+
+        @POST
+        public FormValidation doCheckMaxProviderCallsPerWindow(@QueryParameter int value) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            if (value < 0) {
+                return FormValidation.error("Max provider calls per window must be 0 or greater.");
+            }
+            return FormValidation.ok();
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
@@ -1,6 +1,8 @@
 package io.jenkins.plugins.explain_error;
 
 import hudson.Extension;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
 import io.jenkins.plugins.explain_error.provider.GeminiProvider;
@@ -8,8 +10,10 @@ import io.jenkins.plugins.explain_error.provider.OllamaProvider;
 import io.jenkins.plugins.explain_error.provider.OpenAIProvider;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
-import org.kohsuke.stapler.DataBoundSetter;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
 
 
 /**
@@ -27,6 +31,12 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
     private String customContext;
 
     private BaseAIProvider aiProvider;
+
+    private boolean enableQuota = false;
+    private QuotaWindow quotaWindow = QuotaWindow.HOURLY;
+    private int maxProviderCallsPerWindow = 100;
+
+    private transient QuotaEnforcer quotaEnforcer;
 
     public GlobalConfigurationImpl() {
         load();
@@ -130,6 +140,75 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
     public void setCustomContext(String customContext) {
         this.customContext = customContext;
 
+    }
+
+    public boolean isEnableQuota() {
+        return enableQuota;
+    }
+
+    @DataBoundSetter
+    public void setEnableQuota(boolean enableQuota) {
+        this.enableQuota = enableQuota;
+    }
+
+    public QuotaWindow getQuotaWindow() {
+        return quotaWindow != null ? quotaWindow : QuotaWindow.HOURLY;
+    }
+
+    @DataBoundSetter
+    public void setQuotaWindow(QuotaWindow quotaWindow) {
+        this.quotaWindow = quotaWindow != null ? quotaWindow : QuotaWindow.HOURLY;
+    }
+
+    public int getMaxProviderCallsPerWindow() {
+        return maxProviderCallsPerWindow;
+    }
+
+    @DataBoundSetter
+    public void setMaxProviderCallsPerWindow(int maxProviderCallsPerWindow) {
+        this.maxProviderCallsPerWindow = Math.max(0, maxProviderCallsPerWindow);
+    }
+
+    /**
+     * Returns the singleton {@link QuotaEnforcer}, creating one lazily if needed
+     * (e.g. after deserialization when {@code transient} fields are not restored).
+     */
+    QuotaEnforcer getQuotaEnforcer() {
+        if (quotaEnforcer == null) {
+            quotaEnforcer = new QuotaEnforcer();
+        }
+        return quotaEnforcer;
+    }
+
+    /**
+     * Attempts to acquire a quota slot for a real AI provider call.
+     *
+     * @return {@code true} if the call is allowed (quota disabled, or within the limit);
+     *         {@code false} if the quota is enabled and has been exceeded
+     */
+    public boolean tryAcquireQuota() {
+        if (!enableQuota) {
+            return true;
+        }
+        return getQuotaEnforcer().tryAcquire(getQuotaWindow(), maxProviderCallsPerWindow);
+    }
+
+    @SuppressWarnings("lgtm[jenkins/no-permission-check]")
+    public ListBoxModel doFillQuotaWindowItems() {
+        ListBoxModel items = new ListBoxModel();
+        for (QuotaWindow window : QuotaWindow.values()) {
+            items.add(window.getDisplayName(), window.name());
+        }
+        return items;
+    }
+
+    @POST
+    public FormValidation doCheckMaxProviderCallsPerWindow(@QueryParameter int value) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        if (value < 0) {
+            return FormValidation.error("Max provider calls per window must be 0 or greater.");
+        }
+        return FormValidation.ok();
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/explain_error/QuotaEnforcer.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/QuotaEnforcer.java
@@ -1,0 +1,56 @@
+package io.jenkins.plugins.explain_error;
+
+/**
+ * Thread-safe counter that enforces a maximum number of AI provider calls within a rolling time window.
+ *
+ * <p>When {@link #tryAcquire(QuotaWindow, int)} is called:
+ * <ol>
+ *   <li>If the current time window has expired the counter is reset and the call is allowed.</li>
+ *   <li>Otherwise the counter is incremented atomically. If the new count exceeds the configured
+ *       maximum, the call is rejected.</li>
+ * </ol>
+ *
+ * <p>The enforcer is intentionally stateless with respect to Jenkins configuration: callers
+ * pass the window and limit on every invocation so the enforcer reacts immediately to
+ * configuration changes without requiring a restart.
+ */
+public class QuotaEnforcer {
+
+    private long windowStartMillis;
+    private int count;
+
+    public QuotaEnforcer() {
+        this.windowStartMillis = System.currentTimeMillis();
+        this.count = 0;
+    }
+
+    /**
+     * Attempt to acquire a quota slot.
+     *
+     * @param window   the time window that governs this quota
+     * @param maxCalls the maximum number of provider calls permitted within the window
+     * @return {@code true} if the call is within the quota and should proceed;
+     *         {@code false} if the quota has been exceeded and the call should be rejected
+     */
+    public synchronized boolean tryAcquire(QuotaWindow window, int maxCalls) {
+        long now = System.currentTimeMillis();
+        if (now - windowStartMillis >= window.getDurationMillis()) {
+            windowStartMillis = now;
+            count = 0;
+        }
+        if (count >= maxCalls) {
+            return false;
+        }
+        count++;
+        return true;
+    }
+
+    /**
+     * Resets the quota counter and starts a fresh window.
+     * Intended for testing and for manual admin resets.
+     */
+    public synchronized void reset() {
+        windowStartMillis = System.currentTimeMillis();
+        count = 0;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/explain_error/QuotaWindow.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/QuotaWindow.java
@@ -1,0 +1,26 @@
+package io.jenkins.plugins.explain_error;
+
+/**
+ * Time window options for rate-limiting AI provider calls.
+ */
+public enum QuotaWindow {
+
+    HOURLY("Hourly", 60L * 60 * 1000),
+    DAILY("Daily", 24L * 60 * 60 * 1000);
+
+    private final String displayName;
+    private final long durationMillis;
+
+    QuotaWindow(String displayName, long durationMillis) {
+        this.displayName = displayName;
+        this.durationMillis = durationMillis;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public long getDurationMillis() {
+        return durationMillis;
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty/config.jelly
@@ -2,6 +2,16 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:optionalBlock field="enableExplanation" title="Enable AI Error Explanation" checked="${instance.enableExplanation}" inline="true">
         <f:dropdownDescriptorSelector title="AI Provider" field="aiProvider"/>
+        <f:optionalBlock field="enableQuota" title="Enable Request Quota"
+                         checked="${instance.enableQuota}" inline="true">
+          <f:entry title="Quota Window" field="quotaWindow">
+            <f:select />
+          </f:entry>
+          <f:entry title="Max Provider Calls per Window" field="maxProviderCallsPerWindow"
+                   description="Maximum number of real AI provider calls allowed within the quota window. Overrides the global quota when configured. Cache hits do not count toward this limit.">
+            <f:number clazz="setting-input" min="0" />
+          </f:entry>
+        </f:optionalBlock>
         <f:block>
             <p class="jenkins-!-margin-top-3">
                 <strong>Note:</strong> Folder-level configuration takes precedence over global configuration.

--- a/src/main/resources/io/jenkins/plugins/explain_error/GlobalConfigurationImpl/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/GlobalConfigurationImpl/config.jelly
@@ -8,6 +8,16 @@
                  description="Additional instructions or context for the AI (e.g., KB article links, organization-specific troubleshooting steps). This can be overridden at the job level.">
           <f:textarea />
         </f:entry>
+        <f:optionalBlock field="enableQuota" title="Enable Request Quota"
+                         checked="${it.enableQuota}" inline="true">
+          <f:entry title="Quota Window" field="quotaWindow">
+            <f:select />
+          </f:entry>
+          <f:entry title="Max Provider Calls per Window" field="maxProviderCallsPerWindow"
+                   description="Maximum number of real AI provider calls allowed within the quota window. Cache hits do not count toward this limit.">
+            <f:number clazz="setting-input" min="0" />
+          </f:entry>
+        </f:optionalBlock>
       </f:optionalBlock>
     </f:section>
 </j:jelly>

--- a/src/test/java/io/jenkins/plugins/explain_error/QuotaEnforcerTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/QuotaEnforcerTest.java
@@ -1,0 +1,52 @@
+package io.jenkins.plugins.explain_error;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class QuotaEnforcerTest {
+
+    @Test
+    void allowsCallsWithinLimit() {
+        QuotaEnforcer enforcer = new QuotaEnforcer();
+        assertTrue(enforcer.tryAcquire(QuotaWindow.HOURLY, 3));
+        assertTrue(enforcer.tryAcquire(QuotaWindow.HOURLY, 3));
+        assertTrue(enforcer.tryAcquire(QuotaWindow.HOURLY, 3));
+    }
+
+    @Test
+    void rejectsCallAtLimit() {
+        QuotaEnforcer enforcer = new QuotaEnforcer();
+        assertTrue(enforcer.tryAcquire(QuotaWindow.HOURLY, 1));
+        assertFalse(enforcer.tryAcquire(QuotaWindow.HOURLY, 1));
+    }
+
+    @Test
+    void rejectsAllCallsWhenLimitIsZero() {
+        QuotaEnforcer enforcer = new QuotaEnforcer();
+        assertFalse(enforcer.tryAcquire(QuotaWindow.HOURLY, 0));
+        assertFalse(enforcer.tryAcquire(QuotaWindow.DAILY, 0));
+    }
+
+    @Test
+    void resetAllowsCallsAgainAfterLimitReached() {
+        QuotaEnforcer enforcer = new QuotaEnforcer();
+
+        // Fill up the window
+        assertTrue(enforcer.tryAcquire(QuotaWindow.HOURLY, 1));
+        assertFalse(enforcer.tryAcquire(QuotaWindow.HOURLY, 1));
+
+        // Simulate window rollover by resetting
+        enforcer.reset();
+        assertTrue(enforcer.tryAcquire(QuotaWindow.HOURLY, 1));
+    }
+
+    @Test
+    void dailyWindowEnforcesItsOwnLimit() {
+        QuotaEnforcer enforcer = new QuotaEnforcer();
+        assertTrue(enforcer.tryAcquire(QuotaWindow.DAILY, 2));
+        assertTrue(enforcer.tryAcquire(QuotaWindow.DAILY, 2));
+        assertFalse(enforcer.tryAcquire(QuotaWindow.DAILY, 2));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/explain_error/UsageTrackingTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/UsageTrackingTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.cloudbees.hudson.plugins.folder.Folder;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import io.jenkins.plugins.explain_error.provider.OpenAIProvider;
@@ -45,6 +46,10 @@ class UsageTrackingTest {
             GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
             config.setEnableExplanation(true);
             config.setAiProvider(null);
+            config.setEnableQuota(false);
+            config.setMaxProviderCallsPerWindow(100);
+            config.setQuotaWindow(QuotaWindow.HOURLY);
+            config.getQuotaEnforcer().reset();
         }
     }
 
@@ -172,6 +177,101 @@ class UsageTrackingTest {
         provider.explainError("Direct provider call", null);
 
         assertTrue(recorder.events.isEmpty());
+    }
+
+    @Test
+    void quotaRejectedEmitsUsageEventAndDoesNotCallProvider(JenkinsRule jenkins) throws Exception {
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        config.setAiProvider(new TestProvider());
+        config.setEnableQuota(true);
+        config.setQuotaWindow(QuotaWindow.HOURLY);
+        config.setMaxProviderCallsPerWindow(0);
+
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "usage-quota-rejected");
+        job.setDefinition(new CpsFlowDefinition("node {\n  explainError()\n}", true));
+
+        WorkflowRun run = jenkins.buildAndAssertSuccess(job);
+
+        assertEquals(1, recorder.events.size());
+        UsageEvent event = recorder.events.get(0);
+        assertEquals(UsageEvent.EntryPoint.PIPELINE_STEP, event.entryPoint());
+        assertEquals(UsageEvent.Result.QUOTA_REJECTED, event.result());
+        assertEquals("Test", event.providerName());
+        assertEquals("test-model", event.model());
+        assertEquals(0, event.inputLogLineCount());
+        jenkins.assertLogContains("Provider call quota exceeded. Limit: 0 calls per hourly window.", run);
+    }
+
+    @Test
+    void quotaDisabledAllowsRequestsNormally(JenkinsRule jenkins) throws Exception {
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        config.setAiProvider(new TestProvider());
+        config.setEnableQuota(false);
+
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "usage-quota-disabled");
+        job.setDefinition(new CpsFlowDefinition("node {\n  explainError()\n}", true));
+
+        WorkflowRun run = jenkins.buildAndAssertSuccess(job);
+
+        assertEquals(1, recorder.events.size());
+        UsageEvent event = recorder.events.get(0);
+        assertEquals(UsageEvent.Result.SUCCESS, event.result());
+        assertTrue(run.getAction(ErrorExplanationAction.class).hasValidExplanation());
+    }
+
+    @Test
+    void folderQuotaOverridesGlobalQuotaWhenExceeded(JenkinsRule jenkins) throws Exception {
+        // Global quota is permissive (100 calls), but folder quota is zero
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        config.setAiProvider(new TestProvider());
+        config.setEnableQuota(true);
+        config.setMaxProviderCallsPerWindow(100);
+
+        Folder folder = jenkins.jenkins.createProject(Folder.class, "quota-folder");
+        ExplainErrorFolderProperty folderProperty = new ExplainErrorFolderProperty();
+        folderProperty.setEnableExplanation(true);
+        folderProperty.setAiProvider(new TestProvider());
+        folderProperty.setEnableQuota(true);
+        folderProperty.setMaxProviderCallsPerWindow(0);
+        folderProperty.setQuotaWindow(QuotaWindow.HOURLY);
+        folder.addProperty(folderProperty);
+
+        WorkflowJob job = folder.createProject(WorkflowJob.class, "quota-job");
+        job.setDefinition(new CpsFlowDefinition("node {\n  explainError()\n}", true));
+
+        WorkflowRun run = jenkins.buildAndAssertSuccess(job);
+
+        assertEquals(1, recorder.events.size());
+        UsageEvent event = recorder.events.get(0);
+        assertEquals(UsageEvent.Result.QUOTA_REJECTED, event.result());
+        jenkins.assertLogContains("Provider call quota exceeded (folder level). Limit: 0 calls per hourly window.", run);
+    }
+
+    @Test
+    void folderWithoutQuotaFallsBackToGlobalQuota(JenkinsRule jenkins) throws Exception {
+        // Global quota is zero; the folder has its own provider but NO quota enabled
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        config.setAiProvider(new TestProvider());
+        config.setEnableQuota(true);
+        config.setMaxProviderCallsPerWindow(0);
+        config.setQuotaWindow(QuotaWindow.DAILY);
+
+        Folder folder = jenkins.jenkins.createProject(Folder.class, "no-quota-folder");
+        ExplainErrorFolderProperty folderProperty = new ExplainErrorFolderProperty();
+        folderProperty.setEnableExplanation(true);
+        folderProperty.setAiProvider(new TestProvider());
+        folderProperty.setEnableQuota(false); // no folder-level quota
+        folder.addProperty(folderProperty);
+
+        WorkflowJob job = folder.createProject(WorkflowJob.class, "fallback-quota-job");
+        job.setDefinition(new CpsFlowDefinition("node {\n  explainError()\n}", true));
+
+        WorkflowRun run = jenkins.buildAndAssertSuccess(job);
+
+        assertEquals(1, recorder.events.size());
+        UsageEvent event = recorder.events.get(0);
+        assertEquals(UsageEvent.Result.QUOTA_REJECTED, event.result());
+        jenkins.assertLogContains("Provider call quota exceeded. Limit: 0 calls per daily window.", run);
     }
 
     private static class RecordingUsageRecorder implements UsageRecorder {


### PR DESCRIPTION
### Description

Add optional usage quotas for Explain Error provider calls and documents 

<!-- Please describe the changes in this PR. -->

### Related Issues

Fixes #132. Follow up with #135 and #133

### Testing done

Tested folder-leve

```bash
Pipeline] explainError
[explain-error] Starting explanation for [Team A/Case 01 - Default #16].
[explain-error] Explanation is enabled via folder configuration.
[explain-error] Using provider OpenAI, model gpt-4.1-mini.
[explain-error] Provider call quota exceeded (folder level). Limit: 2 calls per hourly window.
[Pipeline] }
```

Tested global-level
```bash
[Pipeline] explainError
[explain-error] Starting explanation for [Team B/Case 01 - Default #15].
[explain-error] Explanation is enabled via global configuration.
[explain-error] Using provider OpenAI, model gpt-4.1.
[explain-error] Extracting failure logs.
[explain-error] Extracted 9 log lines from the failing step.
[explain-error] Downstream log collection is disabled.
[explain-error] Custom context source: global.
[explain-error] Sending AI request.
[explain-error] AI request completed successfully.
[explain-error] Explanation saved to the build.
[Pipeline] }
```


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[x]` and fill in the tool details.
Uncomment the "Generated-by" trailer in the commit message if applicable.
-->

- [x] Yes (please specify below)


Generated-by: Copilot 
