### PR TITLE
fix: disable Ollama thinking trace to prevent JSON parsing failures

### DIFF
--- a/src/main/java/io/jenkins/plugins/explain_error/provider/OllamaProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/OllamaProvider.java
@@ -47,6 +47,7 @@ public class OllamaProvider extends BaseAIProvider {
                 .modelName(getModel())
                 .temperature(0.3)
                 .responseFormat(ResponseFormat.JSON)
+                .think(false)
                 .timeout(Duration.ofSeconds(180))
                 .logRequests(LOGGER.isLoggable(Level.FINE))
                 .logResponses(LOGGER.isLoggable(Level.FINE))


### PR DESCRIPTION
The explain-error plugin was encountering a `SEVERE` parsing error and crashing during deserialization. Newer reasoning models (e.g., Qwen 3 via Ollama) include a reasoning trace (thinking block) by default. This trace was being mixed into the response, breaking the strict JSON schema expected by the `JenkinsLogAnalysis` parser.

This commit resolves the issue by adding `.think(false)` to the `OllamaChatModel` builder. This explicitly instructs the Ollama API to suppress the reasoning trace, ensuring the model returns only the clean, valid JSON object required by the plugin.

### Description

I was not able to parse the yocto build failuire for a new block in json reply:

[LF]> - status code: 200
[LF]> - headers: [content-type: application/json; charset=utf-8], [date: Thu, 07 May 2026 21:13:35 GMT], [transfer-encoding: chunked]
[LF]> - body: {"model":"qwen3:14b","created_at":"2026-05-07T21:13:35.158496873Z","message":{"role":"assistant","content":"{\n  \"errorSummary\": \"The SDK population step failed due to unmet dependencies during package installation. Key missing packages include xorgproto-dev (required by multiple X11-related packages) and a specific version of mesa-dev (2:26.0.3-r0). This indicates a misconfiguration in the build environment's package dependencies or incompatible Yocto layer versions.\",\n  \"resolutionSteps\": [\n    \"Verify that the meta-x11 layer is included in your Yocto build configuration (check BBLAYERS in conf/bblayers.conf).\",\n    \"Ensure xorgproto-dev is available in your Yocto distribution. If using a custom layer, confirm it contains the required package recipes.\",\n    \"Check Yocto version compatibility with the mesa version specified (2:26.0.3-r0). Consider upgrading to a Yocto version that includes this mesa version or adjust the recipe to use a compatible version.\",\n    \"Run 'bitbake -g \u003crecipe-name\u003e' to analyze dependencies and identify missing packages.\",\n    \"If using a minimal image, consider adding the 'x11' or 'xorg' feature to the image recipe to include necessary components.\"\n  ],\n  \"additionalContext\": {\n    \"missingPackages\": [\"xorgproto-dev\", \"libice-dev\", \"libx11-dev\", \"mesa-dev\"],\n    \"affectedLayers\": [\"meta-x11\", \"meta-mesa\"],\n    \"possibleRootCauses\": [\n      \"Missing or outdated Yocto layers containing X11/mesa packages\",\n      \"Incompatible package version requirements in the build configuration\",\n      \"Custom image recipe excluding necessary X11 dependencies\"\n    ]\n  }\n}","thinking":"Okay, let's tackle this problem. The user is facing an error during the SDK population step in a Yocto build. The error message points to unmet dependencies, specifically mentioning packages like libice-dev, libx11-dev, and others depending on xorgproto-dev, which isn't installable. Also, mesa-dev requires a specific version of mesa that's not available.\n\nFirst, I need to understand why xorgproto-dev isn't installable. Maybe the build environment doesn't have the necessary repositories or the package is missing from the Yocto layers. Another possibility is that the version of the packages required isn't present in the current Yocto release.\n\nLooking at the error, several X11-related packages are failing because they depend on xorgproto-dev. This suggests that the Xorg protocol headers might not be included in the build configuration. The user might be using a minimal image or a custom layer that excludes these packages.\n\nThe mesa-dev error mentions a specific version (2:26.0.3-r0) that's not found. This could be due to the Yocto version being incompatible or the mesa package not being available in the current setup. Maybe the build is using an older Yocto version that doesn't include the required mesa version.\n\nPossible solutions: Check if the required packages are available in the Yocto layers. The user might need to add the meta-x11 layer or ensure that the xorgproto-dev is included. Also, verifying the Yocto version compatibility with the mesa version specified could help. Another step is to check for any missing dependencies in the BitBake configuration or the image recipe that might exclude necessary components.\n\nThe user should also consider updating their Yocto setup to a version that includes the required packages or adjust the recipe to use compatible versions. If the problem persists, checking the Yocto mailing lists or forums for similar issues might provide insights.\n"},"done":true,"done_reason":"stop","total_duration":34939081443,"load_duration":182020403,"prompt_eval_count":1130,"prompt_eval_duration":1213597360,"eval_count":354,"eval_duration":12653900248}

2026-05-07 21:13:35.177+0000 [id=686]	SEVERE	i.j.p.e.provider.BaseAIProvider#explainError: AI API request failed: Failed to parse "{
[LF]>   "errorSummary": "The SDK population step failed due to unmet dependencies during package installation. Key missing packages include xorgproto-dev (required by multiple X11-related packages) and a specific version of mesa-dev (2:26.0.3-r0). This indicates a misconfiguration in the build environment's package dependencies or incompatible Yocto layer versions.",
[LF]>   "resolutionSteps": [
[LF]>     "Verify that the meta-x11 layer is included in your Yocto build configuration (check BBLAYERS in conf/bblayers.conf).",
[LF]>     "Ensure xorgproto-dev is available in your Yocto distribution. If using a custom layer, confirm it contains the required package recipes.",
[LF]>     "Check Yocto version compatibility with the mesa version specified (2:26.0.3-r0). Consider upgrading to a Yocto version that includes this mesa version or adjust the recipe to use a compatible version.",

https://docs.ollama.com/capabilities/thinking

### Related Issues

<!-- Link any related issues, e.g. Fixes #123 -->

### Testing done

<!-- Please describe any testing done to verify the changes in this PR. -->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X ] Ensure that the pull request title represents the desired changelog entry
- [ X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[x]` and fill in the tool details.
Uncomment the "Generated-by" trailer in the commit message if applicable.
-->

- [ ] Yes (please specify below)

<!--
Generated-by: [Tool Name] [Model Name]

Be sure you understand the code generated by AI and reviewed it before creating the PR.
-->
