### PR TITLE
Fix autoFix fails with "SCM credentials not found" in post block

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ post {
 | **workspaceContextPaths** | Comma-separated file paths or glob patterns to include when workspace context is enabled | Common build/config files |
 | **workspaceContextMaxBytes** | Maximum total bytes of workspace context to include | `20000` |
 | **autoFix** | Enable AI auto-fix: the plugin will attempt to generate and commit a code fix, then open a pull request | `false` |
-| **autoFixCredentialsId** | Jenkins credentials ID for a personal access token with write access to the repository | `''` |
+| **autoFixCredentialsId** | Jenkins credentials ID for a personal access token with write access to the repository. Supports Secret text and Username with password credentials. | `''` |
 | **autoFixScmType** | SCM type override: `github`, `gitlab`, or `bitbucket`. Required for self-hosted instances whose hostname is not `github.com`, `gitlab.com`, or `bitbucket.org` | Auto-detected from remote URL |
 | **autoFixGithubEnterpriseUrl** | Base URL of your GitHub Enterprise instance (e.g. `https://github.company.com`) | `''` (uses `api.github.com`) |
 | **autoFixGitlabUrl** | Base URL of your self-hosted GitLab instance (e.g. `https://gitlab.company.com`) | `''` (uses `gitlab.com`) |
@@ -391,7 +391,7 @@ post {
     failure {
         explainError(
             autoFix: true,
-            autoFixCredentialsId: 'github-pat'  // Jenkins credential with repo write access
+            autoFixCredentialsId: 'github-pat'  // Secret text or Username with password credential with repo write access
         )
     }
 }

--- a/docs/auto-fix.md
+++ b/docs/auto-fix.md
@@ -36,8 +36,9 @@ build is marked with status `FAILED` — the original build result is not affect
 
 ## Step 1 — Create a PAT and store it in Jenkins
 
-The plugin uses a **Jenkins StringCredentials** (plain secret text) — not SSH keys, not
-username/password credentials.
+The plugin uses a Jenkins **Secret text** credential or a **Username with password**
+credential. For username/password credentials, the password field is used as the SCM token.
+SSH keys are not supported for auto-fix API calls.
 
 ### GitHub
 
@@ -62,14 +63,14 @@ For **GitHub Enterprise**, use `https://<your-ghe-host>/settings/tokens`.
    store only the app password value; set your Bitbucket username separately if needed)
 
 > Bitbucket Cloud uses `username:apppassword` as the HTTP Basic Auth credential.
-> Store only the app-password value as a StringCredentials in Jenkins; the plugin uses
+> Store only the app-password value in Jenkins; the plugin uses
 > the repository owner from the remote URL as the username.
 
 ### Add to Jenkins
 
 1. **Manage Jenkins → Credentials → (global) → Add Credentials**
-2. Kind: **Secret text**
-3. Secret: paste your token
+2. Kind: **Secret text** or **Username with password**
+3. Secret/password: paste your token
 4. ID: choose a memorable ID (e.g. `github-autofix-pat`)
 
 ---
@@ -226,7 +227,7 @@ The PR description includes:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `autoFix` | boolean | `false` | Enable auto-fix. Must be `true` to activate the feature |
-| `autoFixCredentialsId` | string | `''` | **Required.** Jenkins StringCredentials ID for the SCM token |
+| `autoFixCredentialsId` | string | `''` | **Required.** Jenkins Secret text or Username with password credentials ID for the SCM token |
 | `autoFixRemoteUrl` | string | `''` | SCM remote URL. Auto-detected from job SCM config if empty |
 | `autoFixScmType` | string | `''` | Force SCM type: `github`, `gitlab`, `bitbucket`, or `bitbucketserver`. Required for self-hosted instances whose hostname is not `github.com`, `gitlab.com`, or `bitbucket.org` |
 | `autoFixGithubEnterpriseUrl` | string | `''` | Base URL of GitHub Enterprise (e.g. `https://github.mycompany.com`) |
@@ -337,8 +338,9 @@ explainError(autoFix: true, autoFixCredentialsId: 'my-github-pat')
 
 ### "SCM credentials not found for ID: …"
 
-The credentials ID you provided does not exist in Jenkins, or the build does not have
-permission to access it. Check **Manage Jenkins → Credentials**.
+The credentials ID you provided does not exist in Jenkins, the credential type is not
+Secret text or Username with password, or the build does not have permission to access it.
+Check **Manage Jenkins → Credentials**.
 
 ### "No SCM configured on this job" / "Job type … does not support SCM URL extraction"
 

--- a/src/main/java/io/jenkins/plugins/explain_error/autofix/AutoFixOrchestrator.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/autofix/AutoFixOrchestrator.java
@@ -1,12 +1,14 @@
 package io.jenkins.plugins.explain_error.autofix;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.model.AbstractProject;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.scm.SCM;
+import hudson.util.Secret;
 import io.jenkins.plugins.explain_error.autofix.scm.ScmApiClient;
 import io.jenkins.plugins.explain_error.autofix.scm.ScmClientFactory;
 import io.jenkins.plugins.explain_error.autofix.scm.PullRequest;
@@ -99,7 +101,7 @@ public class AutoFixOrchestrator {
      * @param run                 the failing build run
      * @param errorLogs           the error logs to analyse
      * @param aiProvider          the configured AI provider
-     * @param credentialsId       Jenkins credentials ID for SCM token (StringCredentials)
+     * @param credentialsId       Jenkins credentials ID for SCM token
      * @param remoteUrl           explicit SCM remote URL; if null or blank, extracted from the job's SCM config
      * @param scmTypeOverride     optional override for SCM type detection ("github"/"gitlab"/"bitbucket")
      * @param githubEnterpriseUrl optional GitHub Enterprise API base URL (e.g. https://ghe.example.com)
@@ -153,10 +155,9 @@ public class AutoFixOrchestrator {
                 try {
                     String resolvedUrl = (remoteUrl != null && !remoteUrl.isBlank())
                             ? remoteUrl : extractRemoteUrl(run);
-                    StringCredentials creds = CredentialsProvider.findCredentialById(
-                            credentialsId, StringCredentials.class, run, Collections.emptyList());
-                    if (creds != null) {
-                        ScmRepo repo = buildScmRepo(resolvedUrl, creds.getSecret().getPlainText(),
+                    String token = resolveScmToken(credentialsId, run);
+                    if (token != null) {
+                        ScmRepo repo = buildScmRepo(resolvedUrl, token,
                                 scmTypeOverride, githubEnterpriseUrl, gitlabUrl, bitbucketUrl);
                         ScmApiClient client = ScmClientFactory.create(repo);
                         client.deleteBranch(createdBranchRef[0]);
@@ -255,12 +256,10 @@ public class AutoFixOrchestrator {
                 ? remoteUrl : extractRemoteUrl(run);
         listener.getLogger().println("[AutoFix] SCM remote: " + resolvedRemoteUrl);
 
-        StringCredentials creds = CredentialsProvider.findCredentialById(
-                credentialsId, StringCredentials.class, run, Collections.emptyList());
-        if (creds == null) {
+        String token = resolveScmToken(credentialsId, run);
+        if (token == null) {
             return AutoFixResult.failed("SCM credentials not found for ID: " + credentialsId);
         }
-        String token = creds.getSecret().getPlainText();
 
         // Step 6 — Parse SCM repo (with enterprise overrides)
         ScmRepo repo = buildScmRepo(resolvedRemoteUrl, token, scmTypeOverride,
@@ -367,6 +366,22 @@ public class AutoFixOrchestrator {
     // -------------------------------------------------------------------------
     // Helper methods
     // -------------------------------------------------------------------------
+
+    String resolveScmToken(String credentialsId, Run<?, ?> run) {
+        StringCredentials stringCredentials = CredentialsProvider.findCredentialById(
+                credentialsId, StringCredentials.class, run, Collections.emptyList());
+        if (stringCredentials != null) {
+            return Secret.toString(stringCredentials.getSecret());
+        }
+
+        StandardUsernamePasswordCredentials usernamePasswordCredentials = CredentialsProvider.findCredentialById(
+                credentialsId, StandardUsernamePasswordCredentials.class, run, Collections.emptyList());
+        if (usernamePasswordCredentials != null) {
+            return Secret.toString(usernamePasswordCredentials.getPassword());
+        }
+
+        return null;
+    }
 
     /**
      * Parses a raw string from the AI (which may contain preamble) into a {@link FixSuggestion}.

--- a/src/main/resources/io/jenkins/plugins/explain_error/ExplainErrorStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/ExplainErrorStep/config.jelly
@@ -44,7 +44,7 @@
 
     <f:optionalBlock field="autoFix" title="Enable AI Auto-Fix (create PR)" inline="true">
         <f:entry title="SCM Credentials ID" field="autoFixCredentialsId"
-                 description="Jenkins credentials ID for the SCM token (Personal Access Token with write access).">
+                 description="Jenkins credentials ID for the SCM token. Supports Secret text and Username with password credentials.">
             <f:textbox />
         </f:entry>
 

--- a/src/test/java/io/jenkins/plugins/explain_error/autofix/AutoFixCredentialsTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/autofix/AutoFixCredentialsTest.java
@@ -1,0 +1,75 @@
+package io.jenkins.plugins.explain_error.autofix;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.util.Secret;
+import java.io.IOException;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class AutoFixCredentialsTest {
+
+    @Test
+    void resolveScmToken_supportsSecretTextCredentials(JenkinsRule jenkins) throws Exception {
+        addStringCredential("secret-text-pat", "secret-text-token");
+        FreeStyleBuild run = createRun(jenkins);
+
+        String token = new AutoFixOrchestrator().resolveScmToken("secret-text-pat", run);
+
+        assertEquals("secret-text-token", token);
+    }
+
+    @Test
+    void resolveScmToken_supportsUsernamePasswordCredentials(JenkinsRule jenkins) throws Exception {
+        addUsernamePasswordCredential("username-password-pat", "gitlab-user", "username-password-token");
+        FreeStyleBuild run = createRun(jenkins);
+
+        String token = new AutoFixOrchestrator().resolveScmToken("username-password-pat", run);
+
+        assertEquals("username-password-token", token);
+    }
+
+    @Test
+    void resolveScmToken_missingCredential_returnsNull(JenkinsRule jenkins) throws Exception {
+        FreeStyleBuild run = createRun(jenkins);
+
+        String token = new AutoFixOrchestrator().resolveScmToken("missing-pat", run);
+
+        assertNull(token);
+    }
+
+    private FreeStyleBuild createRun(JenkinsRule jenkins) throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        return jenkins.buildAndAssertSuccess(project);
+    }
+
+    private void addStringCredential(String id, String secret) throws IOException {
+        StringCredentialsImpl credentials = new StringCredentialsImpl(
+                CredentialsScope.GLOBAL,
+                id,
+                "test credential",
+                Secret.fromString(secret));
+        SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        SystemCredentialsProvider.getInstance().save();
+    }
+
+    private void addUsernamePasswordCredential(String id, String username, String password) throws Exception {
+        UsernamePasswordCredentialsImpl credentials = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.GLOBAL,
+                id,
+                "test credential",
+                username,
+                password);
+        SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        SystemCredentialsProvider.getInstance().save();
+    }
+}


### PR DESCRIPTION
* update auto-fix credential descriptions to support Secret text and Username with password types
* implement resolveScmToken method to handle different credential types for SCM tokens
* add unit tests for resolveScmToken method to verify credential resolution

<!-- Please describe the changes in this PR. -->

### Related Issues

Fixes #161 

### Testing done

<!-- Please describe any testing done to verify the changes in this PR. -->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

