### PR TITLE
feat: add Azure OpenAI Responses API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ unclassified:
         apiVersion: "2025-01-01-preview"
         credentialsId: "azure-openai-key" # Jenkins StringCredentials ID
         # apiType: "RESPONSES" # Use Responses API for newer models (e.g. gpt-5.x). Defaults to Chat Completions.
-        # Use apiVersion "2025-04-01-preview" or later when apiType is "RESPONSES".
+        # Responses API uses the Azure OpenAI /openai/v1/responses endpoint.
     enableExplanation: true
 ```
 
@@ -259,11 +259,11 @@ This allows you to manage the plugin configuration alongside your other Jenkins 
 - **Best for**: Generic company AI providers that use Okta for authentication before invoking a custom chat endpoint
 
 ### Azure OpenAI
-- **Models**: Any Azure OpenAI deployment supporting Chat Completions (`/chat/completions`) or Responses API (`/responses`)
+- **Models**: Any Azure OpenAI deployment supporting Chat Completions (`/chat/completions`) or Responses API (`/openai/v1/responses`)
 - **API Key**: Store the Azure OpenAI API key in Jenkins StringCredentials and set its credentials ID
 - **Endpoint**: Azure OpenAI resource endpoint such as `https://my-resource.openai.azure.com`
 - **API Type**: Choose between `Chat Completions API` (legacy, default) and `Responses API` (recommended for newer models like gpt-5.x that do not support chat completions)
-- **API Version**: `Responses API` requires `2025-04-01-preview` or later; `Chat Completions API` defaults to `2025-01-01-preview`
+- **API Version**: Used by `Chat Completions API`; `Responses API` uses the v1 endpoint
 - **Best for**: Azure OpenAI deployments, with support for both legacy and latest API endpoints
 
 ### Google Gemini

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ unclassified:
         apiVersion: "2025-01-01-preview"
         credentialsId: "azure-openai-key" # Jenkins StringCredentials ID
         # apiType: "RESPONSES" # Use Responses API for newer models (e.g. gpt-5.x). Defaults to Chat Completions.
+        # Use apiVersion "2025-04-01-preview" or later when apiType is "RESPONSES".
     enableExplanation: true
 ```
 
@@ -262,6 +263,7 @@ This allows you to manage the plugin configuration alongside your other Jenkins 
 - **API Key**: Store the Azure OpenAI API key in Jenkins StringCredentials and set its credentials ID
 - **Endpoint**: Azure OpenAI resource endpoint such as `https://my-resource.openai.azure.com`
 - **API Type**: Choose between `Chat Completions API` (legacy, default) and `Responses API` (recommended for newer models like gpt-5.x that do not support chat completions)
+- **API Version**: `Responses API` requires `2025-04-01-preview` or later; `Chat Completions API` defaults to `2025-01-01-preview`
 - **Best for**: Azure OpenAI deployments, with support for both legacy and latest API endpoints
 
 ### Google Gemini

--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ unclassified:
     enableExplanation: true
 ```
 
+**Azure OpenAI Configuration:**
+```yaml
+unclassified:
+  explainError:
+    aiProvider:
+      azureOpenai:
+        endpoint: "https://my-resource.openai.azure.com"
+        deployment: "gpt-4o" # Azure OpenAI deployment name
+        apiVersion: "2025-01-01-preview"
+        credentialsId: "azure-openai-key" # Jenkins StringCredentials ID
+        # apiType: "RESPONSES" # Use Responses API for newer models (e.g. gpt-5.x). Defaults to Chat Completions.
+    enableExplanation: true
+```
+
 **Microsoft Foundry Configuration:**
 ```yaml
 unclassified:
@@ -242,6 +256,13 @@ This allows you to manage the plugin configuration alongside your other Jenkins 
 - **App Key Support**: Optional `appKey` and `userId` fields populate the OpenAI-style `user` metadata payload for providers that require an application key
 - **Access Token Delivery**: Configurable header name and optional prefix so the same provider can support `Authorization: Bearer ...`, `api-key: ...`, and similar patterns
 - **Best for**: Generic company AI providers that use Okta for authentication before invoking a custom chat endpoint
+
+### Azure OpenAI
+- **Models**: Any Azure OpenAI deployment supporting Chat Completions (`/chat/completions`) or Responses API (`/responses`)
+- **API Key**: Store the Azure OpenAI API key in Jenkins StringCredentials and set its credentials ID
+- **Endpoint**: Azure OpenAI resource endpoint such as `https://my-resource.openai.azure.com`
+- **API Type**: Choose between `Chat Completions API` (legacy, default) and `Responses API` (recommended for newer models like gpt-5.x that do not support chat completions)
+- **Best for**: Azure OpenAI deployments, with support for both legacy and latest API endpoints
 
 ### Google Gemini
 - **Models**: `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-2.5-flash`, etc.

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
@@ -600,6 +600,8 @@ public class AzureOpenAIProvider extends BaseAIProvider {
          *
          * @return API type options.
          */
+        @POST
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         public ListBoxModel doFillApiTypeItems() {
             ListBoxModel items = new ListBoxModel();
             for (ApiType value : ApiType.values()) {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
@@ -24,8 +24,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -49,9 +47,11 @@ public class AzureOpenAIProvider extends BaseAIProvider {
 
     public static final String DEFAULT_DEPLOYMENT = "gpt-4o";
     public static final String DEFAULT_API_VERSION = "2025-01-01-preview";
-    public static final String RESPONSES_MIN_API_VERSION = "2025-04-01-preview";
-    private static final LocalDate RESPONSES_MIN_API_VERSION_DATE = LocalDate.of(2025, 4, 1);
     public static final int DEFAULT_TIMEOUT_SECONDS = 180;
+    private static final String RESPONSES_API_PATH = "/openai/v1/responses";
+    private static final int ANALYSIS_MAX_OUTPUT_TOKENS = 1000;
+    private static final int FIX_MAX_OUTPUT_TOKENS = 2000;
+    private static final int TEST_MAX_OUTPUT_TOKENS = 32;
 
     /**
      * The Azure OpenAI API type to use for requests.
@@ -161,12 +161,8 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         String deployment = Util.fixEmptyAndTrim(getDeployment());
         String configuredApiVersion = Util.fixEmptyAndTrim(getApiVersion());
         String configuredCredentialsId = Util.fixEmptyAndTrim(getCredentialsId());
-        boolean unsupportedResponsesApiVersion = configuredApiVersion != null
-                && getApiType() == ApiType.RESPONSES
-                && isResponsesApiVersionUnsupported(configuredApiVersion);
         StringCredentials credentials = null;
-        if (endpoint != null && deployment != null && configuredApiVersion != null && configuredCredentialsId != null
-                && !unsupportedResponsesApiVersion) {
+        if (endpoint != null && deployment != null && configuredApiVersion != null && configuredCredentialsId != null) {
             credentials = resolveCredentials(item, authentication);
         }
 
@@ -177,8 +173,6 @@ public class AzureOpenAIProvider extends BaseAIProvider {
                 listener.getLogger().println("No deployment configured for Azure OpenAI.");
             } else if (configuredApiVersion == null) {
                 listener.getLogger().println("No API version configured for Azure OpenAI.");
-            } else if (unsupportedResponsesApiVersion) {
-                listener.getLogger().println(getUnsupportedResponsesApiVersionMessage());
             } else if (configuredCredentialsId == null) {
                 listener.getLogger().println("No credentials ID configured for Azure OpenAI.");
             } else if (credentials == null) {
@@ -187,7 +181,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         }
 
         return endpoint == null || deployment == null || configuredApiVersion == null
-                || unsupportedResponsesApiVersion || configuredCredentialsId == null || credentials == null;
+                || configuredCredentialsId == null || credentials == null;
     }
 
     private JenkinsLogAnalysis requestAnalysis(String errorLogs, String language, String customContext,
@@ -215,6 +209,20 @@ public class AzureOpenAIProvider extends BaseAIProvider {
                 .build();
         try {
             return requestRawContent(client, buildFixRequestBody(errorLogs), item, authentication);
+        } catch (IOException e) {
+            throw new ExplanationException("error", "Failed to communicate with Azure OpenAI", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ExplanationException("error", "Interrupted while communicating with Azure OpenAI", e);
+        }
+    }
+
+    private void testConfiguration() throws ExplanationException {
+        HttpClient client = newJenkinsHttpClientBuilder()
+                .connectTimeout(Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS))
+                .build();
+        try {
+            requestRawContent(client, buildTestRequestBody(), null, null);
         } catch (IOException e) {
             throw new ExplanationException("error", "Failed to communicate with Azure OpenAI", e);
         } catch (InterruptedException e) {
@@ -264,7 +272,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
 
         String apiPath;
         if (getApiType() == ApiType.RESPONSES) {
-            apiPath = "/openai/responses?api-version=" + encodedApiVersion;
+            apiPath = RESPONSES_API_PATH;
         } else {
             apiPath = "/openai/deployments/" + encodedDeployment
                     + "/chat/completions?api-version=" + encodedApiVersion;
@@ -283,6 +291,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
             throws IOException {
         ObjectNode payload = OBJECT_MAPPER.createObjectNode();
         payload.put("temperature", 0.3);
+        payload.put("max_tokens", ANALYSIS_MAX_OUTPUT_TOKENS);
 
         ArrayNode messages = payload.putArray("messages");
         messages.addObject()
@@ -301,6 +310,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         ObjectNode payload = OBJECT_MAPPER.createObjectNode();
         payload.put("model", getDeployment());
         payload.put("store", false);
+        payload.put("max_output_tokens", ANALYSIS_MAX_OUTPUT_TOKENS);
 
         ArrayNode input = payload.putArray("input");
         input.addObject()
@@ -324,6 +334,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
     private String buildChatCompletionsFixRequest(String errorLogs) throws IOException {
         ObjectNode payload = OBJECT_MAPPER.createObjectNode();
         payload.put("temperature", 0.3);
+        payload.put("max_tokens", FIX_MAX_OUTPUT_TOKENS);
 
         ArrayNode messages = payload.putArray("messages");
         messages.addObject()
@@ -340,6 +351,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         ObjectNode payload = OBJECT_MAPPER.createObjectNode();
         payload.put("model", getDeployment());
         payload.put("store", false);
+        payload.put("max_output_tokens", FIX_MAX_OUTPUT_TOKENS);
 
         ArrayNode input = payload.putArray("input");
         input.addObject()
@@ -348,6 +360,40 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         input.addObject()
                 .put("role", "user")
                 .put("content", "Jenkins build failed. Analyze and suggest a fix.\n\nError logs:\n" + errorLogs);
+
+        return OBJECT_MAPPER.writeValueAsString(payload);
+    }
+
+    private String buildTestRequestBody() throws IOException {
+        if (getApiType() == ApiType.RESPONSES) {
+            return buildResponsesTestRequest();
+        }
+        return buildChatCompletionsTestRequest();
+    }
+
+    private String buildChatCompletionsTestRequest() throws IOException {
+        ObjectNode payload = OBJECT_MAPPER.createObjectNode();
+        payload.put("temperature", 0);
+        payload.put("max_tokens", TEST_MAX_OUTPUT_TOKENS);
+
+        ArrayNode messages = payload.putArray("messages");
+        messages.addObject()
+                .put("role", "system")
+                .put("content", "Reply with exactly: Configuration test successful");
+        messages.addObject()
+                .put("role", "user")
+                .put("content", "Test the connection.");
+
+        return OBJECT_MAPPER.writeValueAsString(payload);
+    }
+
+    private String buildResponsesTestRequest() throws IOException {
+        ObjectNode payload = OBJECT_MAPPER.createObjectNode();
+        payload.put("model", getDeployment());
+        payload.put("store", false);
+        payload.put("max_output_tokens", TEST_MAX_OUTPUT_TOKENS);
+        payload.put("instructions", "Reply with exactly: Configuration test successful");
+        payload.put("input", "Test the connection.");
 
         return OBJECT_MAPPER.writeValueAsString(payload);
     }
@@ -522,28 +568,6 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         return value.substring(0, 500) + "...";
     }
 
-    private static boolean isResponsesApiVersionUnsupported(String apiVersion) {
-        LocalDate apiVersionDate = parseApiVersionDate(apiVersion);
-        return apiVersionDate == null || apiVersionDate.isBefore(RESPONSES_MIN_API_VERSION_DATE);
-    }
-
-    private static LocalDate parseApiVersionDate(String apiVersion) {
-        String trimmed = Util.fixEmptyAndTrim(apiVersion);
-        if (trimmed == null || trimmed.length() < 10) {
-            return null;
-        }
-        try {
-            return LocalDate.parse(trimmed.substring(0, 10));
-        } catch (DateTimeParseException e) {
-            return null;
-        }
-    }
-
-    private static String getUnsupportedResponsesApiVersionMessage() {
-        return "Responses API requires Azure OpenAI api-version "
-                + RESPONSES_MIN_API_VERSION + " or later.";
-    }
-
     private static ApiType parseApiType(String apiType) {
         String trimmed = Util.fixEmptyAndTrim(apiType);
         if (trimmed == null) {
@@ -609,14 +633,10 @@ public class AzureOpenAIProvider extends BaseAIProvider {
             if (value == null || value.isBlank()) {
                 return FormValidation.error("API version is required.");
             }
-            ApiType selectedApiType;
             try {
-                selectedApiType = parseApiType(apiType);
+                parseApiType(apiType);
             } catch (IllegalArgumentException e) {
                 return FormValidation.error("Invalid API type.");
-            }
-            if (selectedApiType == ApiType.RESPONSES && isResponsesApiVersionUnsupported(value)) {
-                return FormValidation.error(getUnsupportedResponsesApiVersionMessage());
             }
             return FormValidation.ok();
         }
@@ -645,13 +665,10 @@ public class AzureOpenAIProvider extends BaseAIProvider {
             } catch (IllegalArgumentException e) {
                 return FormValidation.error("Invalid API type.");
             }
-            if (selectedApiType == ApiType.RESPONSES && isResponsesApiVersionUnsupported(apiVersion)) {
-                return FormValidation.error(getUnsupportedResponsesApiVersionMessage());
-            }
             AzureOpenAIProvider provider = new AzureOpenAIProvider(endpoint, deployment, apiVersion,
                     credentialsId, selectedApiType);
             try {
-                provider.explainError("Send 'Configuration test successful' to me.", null);
+                provider.testConfiguration();
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
                 return FormValidation.error("Configuration test failed: " + e.getMessage(), e);

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
@@ -253,8 +253,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
 
         String apiPath;
         if (getApiType() == ApiType.RESPONSES) {
-            apiPath = "/openai/deployments/" + encodedDeployment
-                    + "/responses?api-version=" + encodedApiVersion;
+            apiPath = "/openai/responses?api-version=" + encodedApiVersion;
         } else {
             apiPath = "/openai/deployments/" + encodedDeployment
                     + "/chat/completions?api-version=" + encodedApiVersion;
@@ -289,6 +288,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
     private String buildResponsesAnalysisRequest(String errorLogs, String language, String customContext)
             throws IOException {
         ObjectNode payload = OBJECT_MAPPER.createObjectNode();
+        payload.put("model", getDeployment());
 
         ArrayNode input = payload.putArray("input");
         input.addObject()
@@ -326,6 +326,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
 
     private String buildResponsesFixRequest(String errorLogs) throws IOException {
         ObjectNode payload = OBJECT_MAPPER.createObjectNode();
+        payload.put("model", getDeployment());
 
         ArrayNode input = payload.putArray("input");
         input.addObject()

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
@@ -48,14 +48,35 @@ public class AzureOpenAIProvider extends BaseAIProvider {
     public static final String DEFAULT_API_VERSION = "2025-01-01-preview";
     public static final int DEFAULT_TIMEOUT_SECONDS = 180;
 
+    /**
+     * The Azure OpenAI API type to use for requests.
+     */
+    public enum ApiType {
+        CHAT_COMPLETIONS("Chat Completions API"),
+        RESPONSES("Responses API");
+
+        private final String displayName;
+
+        ApiType(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+    }
+
     private final String apiVersion;
     private final String credentialsId;
+    private final ApiType apiType;
 
     @DataBoundConstructor
-    public AzureOpenAIProvider(String endpoint, String deployment, String apiVersion, String credentialsId) {
+    public AzureOpenAIProvider(String endpoint, String deployment, String apiVersion,
+                               String credentialsId, ApiType apiType) {
         super(Util.fixEmptyAndTrim(endpoint), Util.fixEmptyAndTrim(deployment));
         this.apiVersion = Util.fixEmptyAndTrim(apiVersion);
         this.credentialsId = Util.fixEmptyAndTrim(credentialsId);
+        this.apiType = apiType != null ? apiType : ApiType.CHAT_COMPLETIONS;
     }
 
     public String getEndpoint() {
@@ -72,6 +93,10 @@ public class AzureOpenAIProvider extends BaseAIProvider {
 
     public String getCredentialsId() {
         return credentialsId;
+    }
+
+    public ApiType getApiType() {
+        return apiType != null ? apiType : ApiType.CHAT_COMPLETIONS;
     }
 
     @Override
@@ -161,8 +186,8 @@ public class AzureOpenAIProvider extends BaseAIProvider {
                 .connectTimeout(Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS))
                 .build();
         try {
-            String content = requestRawContent(client, buildChatRequestBody(errorLogs, language, customContext),
-                    item, authentication);
+            String content = requestRawContent(client,
+                    buildAnalysisRequestBody(errorLogs, language, customContext), item, authentication);
             return parseAnalysis(content);
         } catch (IOException e) {
             throw new ExplanationException("error", "Failed to communicate with Azure OpenAI", e);
@@ -195,7 +220,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
             throw new ExplanationException("error", "Azure OpenAI credentials not found for ID: " + getCredentialsId());
         }
 
-        HttpRequest request = HttpRequest.newBuilder(buildChatUri())
+        HttpRequest request = HttpRequest.newBuilder(buildUri())
                 .timeout(Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS))
                 .header("Accept", "application/json")
                 .header("Content-Type", "application/json")
@@ -207,28 +232,45 @@ public class AzureOpenAIProvider extends BaseAIProvider {
             LOGGER.fine("Sending Azure OpenAI request to " + request.uri());
         }
 
-        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        HttpResponse<String> response = client.send(request,
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
         if (response.statusCode() >= 400) {
-            throw new ExplanationException("error", "Chat completion request failed with status "
+            throw new ExplanationException("error", "Azure OpenAI request failed with status "
                     + response.statusCode() + ": " + abbreviate(response.body()));
         }
 
         JsonNode json = OBJECT_MAPPER.readTree(response.body());
-        return extractAssistantContent(json);
+        return extractContent(json);
     }
 
-    private URI buildChatUri() {
+    private URI buildUri() {
         String endpoint = getEndpoint();
         if (endpoint.endsWith("/")) {
             endpoint = endpoint.substring(0, endpoint.length() - 1);
         }
         String encodedDeployment = URLEncoder.encode(getDeployment(), StandardCharsets.UTF_8);
         String encodedApiVersion = URLEncoder.encode(getApiVersion(), StandardCharsets.UTF_8);
-        return URI.create(endpoint + "/openai/deployments/" + encodedDeployment
-                + "/chat/completions?api-version=" + encodedApiVersion);
+
+        String apiPath;
+        if (getApiType() == ApiType.RESPONSES) {
+            apiPath = "/openai/deployments/" + encodedDeployment
+                    + "/responses?api-version=" + encodedApiVersion;
+        } else {
+            apiPath = "/openai/deployments/" + encodedDeployment
+                    + "/chat/completions?api-version=" + encodedApiVersion;
+        }
+        return URI.create(endpoint + apiPath);
     }
 
-    private String buildChatRequestBody(String errorLogs, String language, String customContext) throws IOException {
+    private String buildAnalysisRequestBody(String errorLogs, String language, String customContext) throws IOException {
+        if (getApiType() == ApiType.RESPONSES) {
+            return buildResponsesAnalysisRequest(errorLogs, language, customContext);
+        }
+        return buildChatCompletionsAnalysisRequest(errorLogs, language, customContext);
+    }
+
+    private String buildChatCompletionsAnalysisRequest(String errorLogs, String language, String customContext)
+            throws IOException {
         ObjectNode payload = OBJECT_MAPPER.createObjectNode();
         payload.put("temperature", 0.3);
 
@@ -244,40 +286,37 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         return OBJECT_MAPPER.writeValueAsString(payload);
     }
 
+    private String buildResponsesAnalysisRequest(String errorLogs, String language, String customContext)
+            throws IOException {
+        ObjectNode payload = OBJECT_MAPPER.createObjectNode();
+
+        ArrayNode input = payload.putArray("input");
+        input.addObject()
+                .put("role", "system")
+                .put("content", buildSystemPrompt());
+        input.addObject()
+                .put("role", "user")
+                .put("content", buildUserPrompt(errorLogs, language, customContext)
+                        + "\n\nReturn ONLY valid JSON with these keys: errorSummary, resolutionSteps, bestPractices, errorSignature.");
+
+        return OBJECT_MAPPER.writeValueAsString(payload);
+    }
+
     private String buildFixRequestBody(String errorLogs) throws IOException {
+        if (getApiType() == ApiType.RESPONSES) {
+            return buildResponsesFixRequest(errorLogs);
+        }
+        return buildChatCompletionsFixRequest(errorLogs);
+    }
+
+    private String buildChatCompletionsFixRequest(String errorLogs) throws IOException {
         ObjectNode payload = OBJECT_MAPPER.createObjectNode();
         payload.put("temperature", 0.3);
 
         ArrayNode messages = payload.putArray("messages");
         messages.addObject()
                 .put("role", "system")
-                .put("content", """
-                        You are an expert Jenkins CI/CD engineer. You analyze build failure logs and generate structured fix suggestions.
-
-                        You MUST respond ONLY with valid JSON matching this exact schema (no other text before or after):
-                        {
-                          "fixable": <boolean>,
-                          "explanation": "<one paragraph explaining the root cause>",
-                          "confidence": "<high|medium|low>",
-                          "fixType": "<dependency|config|code|unknown>",
-                          "changes": [
-                            {
-                              "filePath": "<path relative to repo root, e.g. pom.xml>",
-                              "action": "<modify|create>",
-                              "unifiedDiff": "<standard unified diff, properly escaped for JSON>",
-                              "description": "<one sentence explaining this change>"
-                            }
-                          ]
-                        }
-
-                        Rules:
-                        - Only set fixable=true when confidence is "high" or "medium"
-                        - Only suggest changes to source/config files. NEVER modify: target/, build/, dist/, node_modules/, .gradle/, lock files (package-lock.json, yarn.lock, Pipfile.lock), secrets (.env*, credentials*)
-                        - For unifiedDiff: use standard unified diff format with @@ -line,count +line,count @@ headers
-                        - filePath must be relative to repo root (no leading /, no ../ traversal)
-                        - If you cannot determine a fix with at least medium confidence, set fixable=false and return an empty changes array
-                        - Supported file types: pom.xml, build.gradle, build.gradle.kts, package.json, requirements.txt, go.mod, Gemfile, Jenkinsfile, Dockerfile, *.yaml, *.yml, *.json (config), *.properties, *.xml (config), *.java, *.py, *.js, *.ts (small targeted fixes only)
-                        """);
+                .put("content", getFixSystemPrompt());
         messages.addObject()
                 .put("role", "user")
                 .put("content", "Jenkins build failed. Analyze and suggest a fix.\n\nError logs:\n" + errorLogs);
@@ -285,7 +324,58 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         return OBJECT_MAPPER.writeValueAsString(payload);
     }
 
-    private String extractAssistantContent(JsonNode responseJson) throws ExplanationException {
+    private String buildResponsesFixRequest(String errorLogs) throws IOException {
+        ObjectNode payload = OBJECT_MAPPER.createObjectNode();
+
+        ArrayNode input = payload.putArray("input");
+        input.addObject()
+                .put("role", "system")
+                .put("content", getFixSystemPrompt());
+        input.addObject()
+                .put("role", "user")
+                .put("content", "Jenkins build failed. Analyze and suggest a fix.\n\nError logs:\n" + errorLogs);
+
+        return OBJECT_MAPPER.writeValueAsString(payload);
+    }
+
+    private static String getFixSystemPrompt() {
+        return """
+                You are an expert Jenkins CI/CD engineer. You analyze build failure logs and generate structured fix suggestions.
+
+                You MUST respond ONLY with valid JSON matching this exact schema (no other text before or after):
+                {
+                  "fixable": <boolean>,
+                  "explanation": "<one paragraph explaining the root cause>",
+                  "confidence": "<high|medium|low>",
+                  "fixType": "<dependency|config|code|unknown>",
+                  "changes": [
+                    {
+                      "filePath": "<path relative to repo root, e.g. pom.xml>",
+                      "action": "<modify|create>",
+                      "unifiedDiff": "<standard unified diff, properly escaped for JSON>",
+                      "description": "<one sentence explaining this change>"
+                    }
+                  ]
+                }
+
+                Rules:
+                - Only set fixable=true when confidence is "high" or "medium"
+                - Only suggest changes to source/config files. NEVER modify: target/, build/, dist/, node_modules/, .gradle/, lock files (package-lock.json, yarn.lock, Pipfile.lock), secrets (.env*, credentials*)
+                - For unifiedDiff: use standard unified diff format with @@ -line,count +line,count @@ headers
+                - filePath must be relative to repo root (no leading /, no ../ traversal)
+                - If you cannot determine a fix with at least medium confidence, set fixable=false and return an empty changes array
+                - Supported file types: pom.xml, build.gradle, build.gradle.kts, package.json, requirements.txt, go.mod, Gemfile, Jenkinsfile, Dockerfile, *.yaml, *.yml, *.json (config), *.properties, *.xml (config), *.java, *.py, *.js, *.ts (small targeted fixes only)
+                """;
+    }
+
+    private String extractContent(JsonNode responseJson) throws ExplanationException {
+        if (getApiType() == ApiType.RESPONSES) {
+            return extractResponsesContent(responseJson);
+        }
+        return extractChatCompletionsContent(responseJson);
+    }
+
+    private String extractChatCompletionsContent(JsonNode responseJson) throws ExplanationException {
         JsonNode choices = responseJson.path("choices");
         if (!choices.isArray() || choices.isEmpty()) {
             throw new ExplanationException("error", "Chat completion response did not contain any choices.");
@@ -310,6 +400,31 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         }
 
         throw new ExplanationException("error", "Chat completion response did not contain message content.");
+    }
+
+    private String extractResponsesContent(JsonNode responseJson) throws ExplanationException {
+        JsonNode output = responseJson.path("output");
+        if (!output.isArray() || output.isEmpty()) {
+            throw new ExplanationException("error", "Responses API response did not contain any output.");
+        }
+
+        for (JsonNode item : output) {
+            if ("message".equals(item.path("type").asText(null))) {
+                JsonNode content = item.path("content");
+                if (content.isArray() && !content.isEmpty()) {
+                    for (JsonNode part : content) {
+                        if ("output_text".equals(part.path("type").asText(null))) {
+                            String text = part.path("text").asText(null);
+                            if (text != null) {
+                                return text;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        throw new ExplanationException("error", "Responses API response did not contain output text.");
     }
 
     private JenkinsLogAnalysis parseAnalysis(String content) throws IOException {
@@ -452,11 +567,13 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         public FormValidation doTestConfiguration(@QueryParameter("endpoint") String endpoint,
                                                   @QueryParameter("deployment") String deployment,
                                                   @QueryParameter("apiVersion") String apiVersion,
-                                                  @QueryParameter("credentialsId") String credentialsId)
+                                                  @QueryParameter("credentialsId") String credentialsId,
+                                                  @QueryParameter("apiType") String apiType)
                 throws ExplanationException {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
-            AzureOpenAIProvider provider = new AzureOpenAIProvider(endpoint, deployment, apiVersion, credentialsId);
+            AzureOpenAIProvider provider = new AzureOpenAIProvider(endpoint, deployment, apiVersion,
+                    credentialsId, apiType != null ? ApiType.valueOf(apiType) : null);
             try {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
@@ -13,6 +13,7 @@ import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import io.jenkins.plugins.explain_error.ExplanationException;
 import io.jenkins.plugins.explain_error.JenkinsLogAnalysis;
 import java.io.IOException;
@@ -23,6 +24,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +49,8 @@ public class AzureOpenAIProvider extends BaseAIProvider {
 
     public static final String DEFAULT_DEPLOYMENT = "gpt-4o";
     public static final String DEFAULT_API_VERSION = "2025-01-01-preview";
+    public static final String RESPONSES_MIN_API_VERSION = "2025-04-01-preview";
+    private static final LocalDate RESPONSES_MIN_API_VERSION_DATE = LocalDate.of(2025, 4, 1);
     public static final int DEFAULT_TIMEOUT_SECONDS = 180;
 
     /**
@@ -156,8 +161,12 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         String deployment = Util.fixEmptyAndTrim(getDeployment());
         String configuredApiVersion = Util.fixEmptyAndTrim(getApiVersion());
         String configuredCredentialsId = Util.fixEmptyAndTrim(getCredentialsId());
+        boolean unsupportedResponsesApiVersion = configuredApiVersion != null
+                && getApiType() == ApiType.RESPONSES
+                && isResponsesApiVersionUnsupported(configuredApiVersion);
         StringCredentials credentials = null;
-        if (endpoint != null && deployment != null && configuredApiVersion != null && configuredCredentialsId != null) {
+        if (endpoint != null && deployment != null && configuredApiVersion != null && configuredCredentialsId != null
+                && !unsupportedResponsesApiVersion) {
             credentials = resolveCredentials(item, authentication);
         }
 
@@ -168,6 +177,8 @@ public class AzureOpenAIProvider extends BaseAIProvider {
                 listener.getLogger().println("No deployment configured for Azure OpenAI.");
             } else if (configuredApiVersion == null) {
                 listener.getLogger().println("No API version configured for Azure OpenAI.");
+            } else if (unsupportedResponsesApiVersion) {
+                listener.getLogger().println(getUnsupportedResponsesApiVersionMessage());
             } else if (configuredCredentialsId == null) {
                 listener.getLogger().println("No credentials ID configured for Azure OpenAI.");
             } else if (credentials == null) {
@@ -176,7 +187,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         }
 
         return endpoint == null || deployment == null || configuredApiVersion == null
-                || configuredCredentialsId == null || credentials == null;
+                || unsupportedResponsesApiVersion || configuredCredentialsId == null || credentials == null;
     }
 
     private JenkinsLogAnalysis requestAnalysis(String errorLogs, String language, String customContext,
@@ -289,6 +300,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
             throws IOException {
         ObjectNode payload = OBJECT_MAPPER.createObjectNode();
         payload.put("model", getDeployment());
+        payload.put("store", false);
 
         ArrayNode input = payload.putArray("input");
         input.addObject()
@@ -327,6 +339,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
     private String buildResponsesFixRequest(String errorLogs) throws IOException {
         ObjectNode payload = OBJECT_MAPPER.createObjectNode();
         payload.put("model", getDeployment());
+        payload.put("store", false);
 
         ArrayNode input = payload.putArray("input");
         input.addObject()
@@ -509,6 +522,36 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         return value.substring(0, 500) + "...";
     }
 
+    private static boolean isResponsesApiVersionUnsupported(String apiVersion) {
+        LocalDate apiVersionDate = parseApiVersionDate(apiVersion);
+        return apiVersionDate == null || apiVersionDate.isBefore(RESPONSES_MIN_API_VERSION_DATE);
+    }
+
+    private static LocalDate parseApiVersionDate(String apiVersion) {
+        String trimmed = Util.fixEmptyAndTrim(apiVersion);
+        if (trimmed == null || trimmed.length() < 10) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(trimmed.substring(0, 10));
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    private static String getUnsupportedResponsesApiVersionMessage() {
+        return "Responses API requires Azure OpenAI api-version "
+                + RESPONSES_MIN_API_VERSION + " or later.";
+    }
+
+    private static ApiType parseApiType(String apiType) {
+        String trimmed = Util.fixEmptyAndTrim(apiType);
+        if (trimmed == null) {
+            return null;
+        }
+        return ApiType.valueOf(trimmed);
+    }
+
     @Extension
     @Symbol("azureOpenai")
     public static class DescriptorImpl extends BaseProviderDescriptor {
@@ -526,6 +569,19 @@ public class AzureOpenAIProvider extends BaseAIProvider {
 
         public String getDefaultApiVersion() {
             return DEFAULT_API_VERSION;
+        }
+
+        /**
+         * Returns the selectable Azure OpenAI API types for configuration.
+         *
+         * @return API type options.
+         */
+        public ListBoxModel doFillApiTypeItems() {
+            ListBoxModel items = new ListBoxModel();
+            for (ApiType value : ApiType.values()) {
+                items.add(value.getDisplayName(), value.name());
+            }
+            return items;
         }
 
         @POST
@@ -548,9 +604,19 @@ public class AzureOpenAIProvider extends BaseAIProvider {
 
         @POST
         @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-        public FormValidation doCheckApiVersion(@QueryParameter String value) {
+        public FormValidation doCheckApiVersion(@QueryParameter String value,
+                                                @QueryParameter("apiType") String apiType) {
             if (value == null || value.isBlank()) {
                 return FormValidation.error("API version is required.");
+            }
+            ApiType selectedApiType;
+            try {
+                selectedApiType = parseApiType(apiType);
+            } catch (IllegalArgumentException e) {
+                return FormValidation.error("Invalid API type.");
+            }
+            if (selectedApiType == ApiType.RESPONSES && isResponsesApiVersionUnsupported(value)) {
+                return FormValidation.error(getUnsupportedResponsesApiVersionMessage());
             }
             return FormValidation.ok();
         }
@@ -573,8 +639,17 @@ public class AzureOpenAIProvider extends BaseAIProvider {
                 throws ExplanationException {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
+            ApiType selectedApiType;
+            try {
+                selectedApiType = parseApiType(apiType);
+            } catch (IllegalArgumentException e) {
+                return FormValidation.error("Invalid API type.");
+            }
+            if (selectedApiType == ApiType.RESPONSES && isResponsesApiVersionUnsupported(apiVersion)) {
+                return FormValidation.error(getUnsupportedResponsesApiVersionMessage());
+            }
             AzureOpenAIProvider provider = new AzureOpenAIProvider(endpoint, deployment, apiVersion,
-                    credentialsId, apiType != null ? ApiType.valueOf(apiType) : null);
+                    credentialsId, selectedApiType);
             try {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
@@ -311,6 +311,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         payload.put("model", getDeployment());
         payload.put("store", false);
         payload.put("max_output_tokens", ANALYSIS_MAX_OUTPUT_TOKENS);
+        addGpt5LatencyControls(payload);
 
         ArrayNode input = payload.putArray("input");
         input.addObject()
@@ -352,6 +353,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         payload.put("model", getDeployment());
         payload.put("store", false);
         payload.put("max_output_tokens", FIX_MAX_OUTPUT_TOKENS);
+        addGpt5LatencyControls(payload);
 
         ArrayNode input = payload.putArray("input");
         input.addObject()
@@ -392,10 +394,20 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         payload.put("model", getDeployment());
         payload.put("store", false);
         payload.put("max_output_tokens", TEST_MAX_OUTPUT_TOKENS);
+        addGpt5LatencyControls(payload);
         payload.put("instructions", "Reply with exactly: Configuration test successful");
         payload.put("input", "Test the connection.");
 
         return OBJECT_MAPPER.writeValueAsString(payload);
+    }
+
+    private void addGpt5LatencyControls(ObjectNode payload) {
+        String deployment = Util.fixEmptyAndTrim(getDeployment());
+        if (deployment == null || !deployment.toLowerCase().startsWith("gpt-5")) {
+            return;
+        }
+        payload.putObject("reasoning").put("effort", "minimal");
+        payload.putObject("text").put("verbosity", "low");
     }
 
     private static String getFixSystemPrompt() {
@@ -463,6 +475,17 @@ public class AzureOpenAIProvider extends BaseAIProvider {
     }
 
     private String extractResponsesContent(JsonNode responseJson) throws ExplanationException {
+        JsonNode error = responseJson.path("error");
+        if (error.isObject() && error.hasNonNull("message")) {
+            throw new ExplanationException("error", "Responses API returned an error: "
+                    + error.get("message").asText());
+        }
+
+        JsonNode outputText = responseJson.path("output_text");
+        if (outputText.isTextual() && Util.fixEmptyAndTrim(outputText.asText()) != null) {
+            return outputText.asText();
+        }
+
         JsonNode output = responseJson.path("output");
         if (!output.isArray() || output.isEmpty()) {
             throw new ExplanationException("error", "Responses API response did not contain any output.");

--- a/src/main/resources/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider/config.jelly
@@ -11,7 +11,7 @@
   </f:entry>
 
   <f:entry title="API Version" field="apiVersion"
-           description="Azure OpenAI api-version query parameter. Responses API requires 2025-04-01-preview or later.">
+           description="Azure OpenAI api-version query parameter for Chat Completions. Responses API uses the v1 endpoint.">
     <f:textbox clazz="required" default="${descriptor.defaultApiVersion}"/>
   </f:entry>
 

--- a/src/main/resources/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider/config.jelly
@@ -11,7 +11,7 @@
   </f:entry>
 
   <f:entry title="API Version" field="apiVersion"
-           description="Azure OpenAI api-version query parameter.">
+           description="Azure OpenAI api-version query parameter. Responses API requires 2025-04-01-preview or later.">
     <f:textbox clazz="required" default="${descriptor.defaultApiVersion}"/>
   </f:entry>
 
@@ -22,9 +22,7 @@
 
   <f:entry title="API Type" field="apiType"
            description="Select the API endpoint type. Use Responses API for newer models (e.g. gpt-5.x) that do not support the legacy Chat Completions API.">
-    <f:enum field="apiType">
-      ${it.getApiType().name()}
-    </f:enum>
+    <f:select />
   </f:entry>
 
   <f:validateButton title="Test Configuration" progress="Testing..."

--- a/src/main/resources/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider/config.jelly
@@ -6,7 +6,7 @@
   </f:entry>
 
   <f:entry title="Deployment" field="deployment"
-           description="Azure OpenAI deployment name to call for chat completions.">
+           description="Azure OpenAI deployment name to call.">
     <f:textbox clazz="required" default="${descriptor.defaultModel}"/>
   </f:entry>
 
@@ -20,6 +20,13 @@
     <f:textbox clazz="required"/>
   </f:entry>
 
+  <f:entry title="API Type" field="apiType"
+           description="Select the API endpoint type. Use Responses API for newer models (e.g. gpt-5.x) that do not support the legacy Chat Completions API.">
+    <f:enum field="apiType">
+      ${it.getApiType().name()}
+    </f:enum>
+  </f:entry>
+
   <f:validateButton title="Test Configuration" progress="Testing..."
-                    method="testConfiguration" with="endpoint,deployment,apiVersion,credentialsId" />
+                    method="testConfiguration" with="endpoint,deployment,apiVersion,credentialsId,apiType" />
 </j:jelly>

--- a/src/main/webapp/js/explain-error-footer.js
+++ b/src/main/webapp/js/explain-error-footer.js
@@ -178,12 +178,7 @@ function sendExplainRequest(forceNew = false) {
     headers: headers,
     body: body
   })
-  .then(response => {
-    if (!response.ok) {
-      notificationBar.show('Explain failed', notificationBar.ERROR);
-    }
-    return response.json();
-  })
+  .then(parseJsonResponse)
   .then(json => {
     try {
       if (json.status == "success") {
@@ -199,12 +194,43 @@ function sendExplainRequest(forceNew = false) {
         hideContainer();
       }
     } catch (e) {
-      notificationBar.show(`Error: ${error.message}`, notificationBar.ERROR);
+      notificationBar.show(`Error: ${e.message}`, notificationBar.ERROR);
     }
   })
   .catch(error => {
     notificationBar.show(`Error: ${error.message}`, notificationBar.ERROR);
+    hideContainer();
   });
+}
+
+function parseJsonResponse(response) {
+  return response.text().then(text => {
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      const message = response.ok
+        ? 'Explain failed: Jenkins returned an invalid response.'
+        : `Explain failed with HTTP ${response.status}: ${summarizeHtmlResponse(text)}`;
+      throw new Error(message);
+    }
+  });
+}
+
+function summarizeHtmlResponse(text) {
+  if (!text) {
+    return 'empty response';
+  }
+  const titleMatch = text.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (titleMatch) {
+    return decodeHtml(titleMatch[1]).trim();
+  }
+  return text.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim().substring(0, 200);
+}
+
+function decodeHtml(text) {
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = text;
+  return textarea.value;
 }
 
 function showErrorExplanation(message, providerName, url) {

--- a/src/test/java/io/jenkins/plugins/explain_error/CasCTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/CasCTest.java
@@ -74,6 +74,7 @@ public class CasCTest {
         assertEquals("gpt-4o-enterprise", azure.getDeployment());
         assertEquals("2025-01-01-preview", azure.getApiVersion());
         assertEquals("azure-openai-key", azure.getCredentialsId());
+        assertEquals(AzureOpenAIProvider.ApiType.CHAT_COMPLETIONS, azure.getApiType());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorActionTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorActionTest.java
@@ -125,6 +125,23 @@ class ConsoleExplainErrorActionTest {
     }
 
     @Test
+    void testExplainConsoleErrorProviderFailureReturnsJson() throws IOException {
+        provider.setThrowError(true);
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl() + build.getUrl() + "console-explain-error/explainConsoleError");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+
+            Page page = client.getPage(request);
+            String content = page.getWebResponse().getContentAsString();
+            JSONObject responseJson = JSONObject.fromObject(content);
+
+            assertEquals("error", responseJson.getString("status"));
+            assertEquals("Test", responseJson.getString("providerName"));
+            assertTrue(responseJson.getString("message").contains("API request failed: Request failed."));
+        }
+    }
+
+    @Test
     void testExplainConsoleErrorSecondCall() throws IOException {
         try (JenkinsRule.WebClient client = rule.createWebClient()) {
             URL url = new URL(rule.jenkins.getRootUrl() + build.getUrl() + "console-explain-error/explainConsoleError");

--- a/src/test/java/io/jenkins/plugins/explain_error/ExplainErrorFolderPropertyTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ExplainErrorFolderPropertyTest.java
@@ -190,7 +190,8 @@ class ExplainErrorFolderPropertyTest {
                 "https://my-resource.openai.azure.com",
                 "gpt-4o-enterprise",
                 "2025-01-01-preview",
-                "azure-openai-key"));
+                "azure-openai-key",
+                null));
 
         folder.addProperty(property);
 

--- a/src/test/java/io/jenkins/plugins/explain_error/GlobalConfigurationImplTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/GlobalConfigurationImplTest.java
@@ -127,7 +127,8 @@ class GlobalConfigurationImplTest {
                 "https://my-resource.openai.azure.com",
                 "gpt-4o-enterprise",
                 "2025-01-01-preview",
-                "azure-openai-key");
+                "azure-openai-key",
+                null);
         config.setAiProvider(provider);
         config.save();
 

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.explain_error.provider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -22,7 +21,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.jupiter.api.AfterEach;
@@ -91,6 +89,7 @@ class AzureOpenAIProviderTest {
         assertEquals("test-azure-key", apiKeyHeader.get());
 
         JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
+        assertEquals(1000, payload.path("max_tokens").asInt());
         assertNotNull(payload.path("messages"));
         assertTrue(requestBody.get().contains("Return ONLY valid JSON"));
         assertTrue(explanation.contains("Azure OpenAI worked"));
@@ -105,7 +104,7 @@ class AzureOpenAIProviderTest {
         AtomicReference<String> apiKeyHeader = new AtomicReference<>();
         AtomicReference<String> requestBody = new AtomicReference<>();
 
-        server.createContext("/openai/responses", new JsonHandler(exchange -> {
+        server.createContext("/openai/v1/responses", new JsonHandler(exchange -> {
             requestPath.set(exchange.getRequestURI().toString());
             apiKeyHeader.set(exchange.getRequestHeaders().getFirst("api-key"));
             requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
@@ -131,18 +130,18 @@ class AzureOpenAIProviderTest {
         AzureOpenAIProvider provider = new AzureOpenAIProvider(
                 endpoint,
                 "gpt-5-pro",
-                AzureOpenAIProvider.RESPONSES_MIN_API_VERSION,
+                "2025-01-01-preview",
                 "azure-responses-key",
                 AzureOpenAIProvider.ApiType.RESPONSES);
 
         String explanation = provider.explainError("FAILURE: responses test", null, "English", null);
 
-        assertEquals("/openai/responses?api-version=" + AzureOpenAIProvider.RESPONSES_MIN_API_VERSION,
-                requestPath.get());
+        assertEquals("/openai/v1/responses", requestPath.get());
         assertEquals("test-responses-key", apiKeyHeader.get());
 
         JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
         assertEquals("gpt-5-pro", payload.path("model").asText());
+        assertEquals(1000, payload.path("max_output_tokens").asInt());
         assertTrue(payload.has("store"));
         assertFalse(payload.path("store").asBoolean(true));
         assertNotNull(payload.path("input"));
@@ -187,6 +186,8 @@ class AzureOpenAIProviderTest {
 
         assertEquals("/openai/deployments/fix-deployment/chat/completions?api-version=2025-02-01-preview",
                 requestPath.get());
+        JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
+        assertEquals(2000, payload.path("max_tokens").asInt());
         assertTrue(requestBody.get().contains("\"Jenkins build failed. Analyze and suggest a fix."));
         assertTrue(result.contains("\"fixable\":true"));
     }
@@ -198,7 +199,7 @@ class AzureOpenAIProviderTest {
         AtomicReference<String> requestPath = new AtomicReference<>();
         AtomicReference<String> requestBody = new AtomicReference<>();
 
-        server.createContext("/openai/responses", new JsonHandler(exchange -> {
+        server.createContext("/openai/v1/responses", new JsonHandler(exchange -> {
             requestPath.set(exchange.getRequestURI().toString());
             requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
             return """
@@ -223,18 +224,18 @@ class AzureOpenAIProviderTest {
         AzureOpenAIProvider provider = new AzureOpenAIProvider(
                 endpoint,
                 "gpt-5-fix",
-                AzureOpenAIProvider.RESPONSES_MIN_API_VERSION,
+                "2025-01-01-preview",
                 "azure-fix-responses-key",
                 AzureOpenAIProvider.ApiType.RESPONSES);
 
         FixAssistant assistant = provider.createFixAssistant();
         String result = assistant.suggestFix("FAILURE: obscure error");
 
-        assertEquals("/openai/responses?api-version=" + AzureOpenAIProvider.RESPONSES_MIN_API_VERSION,
-                requestPath.get());
+        assertEquals("/openai/v1/responses", requestPath.get());
 
         JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
         assertEquals("gpt-5-fix", payload.path("model").asText());
+        assertEquals(2000, payload.path("max_output_tokens").asInt());
         assertTrue(payload.has("store"));
         assertFalse(payload.path("store").asBoolean(true));
         assertTrue(result.contains("\"fixable\":false"));
@@ -242,15 +243,14 @@ class AzureOpenAIProviderTest {
     }
 
     @Test
-    void descriptorRejectsUnsupportedResponsesApiVersion() {
+    void descriptorAllowsResponsesApiVersionBecauseV1EndpointIgnoresIt() {
         AzureOpenAIProvider.DescriptorImpl descriptor = new AzureOpenAIProvider.DescriptorImpl();
 
         FormValidation validation = descriptor.doCheckApiVersion(
                 "2025-01-01-preview",
                 AzureOpenAIProvider.ApiType.RESPONSES.name());
 
-        assertEquals(FormValidation.Kind.ERROR, validation.kind);
-        assertTrue(validation.getMessage().contains(AzureOpenAIProvider.RESPONSES_MIN_API_VERSION));
+        assertEquals(FormValidation.Kind.OK, validation.kind);
     }
 
     @Test
@@ -267,13 +267,72 @@ class AzureOpenAIProviderTest {
     }
 
     @Test
-    void responsesApiRejectsUnsupportedApiVersionBeforeRequest(JenkinsRule jenkins) throws Exception {
-        addStringCredential("azure-old-responses-key", "old-responses-key");
-        AtomicInteger requests = new AtomicInteger();
+    void descriptorTestConfigurationUsesLightweightResponsesRequest(JenkinsRule jenkins) throws Exception {
+        addStringCredential("azure-test-responses-key", "test-responses-key");
 
-        server.createContext("/openai/responses", new JsonHandler(exchange -> {
-            requests.incrementAndGet();
-            return "{}";
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        AtomicReference<String> requestBody = new AtomicReference<>();
+
+        server.createContext("/openai/v1/responses", new JsonHandler(exchange -> {
+            requestPath.set(exchange.getRequestURI().toString());
+            requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            return """
+                    {
+                      "output": [
+                        {
+                          "type": "message",
+                          "content": [
+                            {
+                              "type": "output_text",
+                              "text": "Configuration test successful"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """;
+        }));
+
+        AzureOpenAIProvider.DescriptorImpl descriptor = new AzureOpenAIProvider.DescriptorImpl();
+        FormValidation validation = descriptor.doTestConfiguration(
+                "http://127.0.0.1:" + server.getAddress().getPort(),
+                "gpt-5-pro",
+                "2025-01-01-preview",
+                "azure-test-responses-key",
+                AzureOpenAIProvider.ApiType.RESPONSES.name());
+
+        assertEquals(FormValidation.Kind.OK, validation.kind);
+        assertEquals("/openai/v1/responses", requestPath.get());
+
+        JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
+        assertEquals("gpt-5-pro", payload.path("model").asText());
+        assertEquals(32, payload.path("max_output_tokens").asInt());
+        assertEquals("Test the connection.", payload.path("input").asText());
+        assertFalse(requestBody.get().contains("Return ONLY valid JSON"));
+    }
+
+    @Test
+    void responsesApiUsesV1EndpointAndIgnoresConfiguredApiVersion(JenkinsRule jenkins) throws Exception {
+        addStringCredential("azure-old-responses-key", "old-responses-key");
+        AtomicReference<String> requestPath = new AtomicReference<>();
+
+        server.createContext("/openai/v1/responses", new JsonHandler(exchange -> {
+            requestPath.set(exchange.getRequestURI().toString());
+            return """
+                    {
+                      "output": [
+                        {
+                          "type": "message",
+                          "content": [
+                            {
+                              "type": "output_text",
+                              "text": "{\\"errorSummary\\":\\"V1 endpoint worked\\"}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """;
         }));
 
         String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
@@ -284,11 +343,10 @@ class AzureOpenAIProviderTest {
                 "azure-old-responses-key",
                 AzureOpenAIProvider.ApiType.RESPONSES);
 
-        ExplanationException result = assertThrows(ExplanationException.class,
-                () -> provider.explainError("FAILURE: responses test", null, "English", null));
+        String result = provider.explainError("FAILURE: responses test", null, "English", null);
 
-        assertEquals("The provider is not properly configured.", result.getMessage());
-        assertEquals(0, requests.get());
+        assertEquals("/openai/v1/responses", requestPath.get());
+        assertTrue(result.contains("V1 endpoint worked"));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
@@ -46,7 +46,7 @@ class AzureOpenAIProviderTest {
     }
 
     @Test
-    void explainErrorUsesAzureEndpointAndApiKey(JenkinsRule jenkins) throws Exception {
+    void explainErrorUsesAzureChatCompletionsEndpoint(JenkinsRule jenkins) throws Exception {
         addStringCredential("azure-openai-key", "test-azure-key");
 
         AtomicReference<String> requestPath = new AtomicReference<>();
@@ -75,11 +75,13 @@ class AzureOpenAIProviderTest {
                 endpoint,
                 "my-gpt-4o",
                 "2025-01-01-preview",
-                "azure-openai-key");
+                "azure-openai-key",
+                AzureOpenAIProvider.ApiType.CHAT_COMPLETIONS);
 
         String explanation = provider.explainError("FAILURE: sample error", null, "English", "Prioritize root cause");
 
-        assertEquals("/openai/deployments/my-gpt-4o/chat/completions?api-version=2025-01-01-preview", requestPath.get());
+        assertEquals("/openai/deployments/my-gpt-4o/chat/completions?api-version=2025-01-01-preview",
+                requestPath.get());
         assertEquals("test-azure-key", apiKeyHeader.get());
 
         JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
@@ -90,7 +92,58 @@ class AzureOpenAIProviderTest {
     }
 
     @Test
-    void fixAssistantUsesAzureEndpointAndReturnsRawJson(JenkinsRule jenkins) throws Exception {
+    void explainErrorUsesAzureResponsesEndpoint(JenkinsRule jenkins) throws Exception {
+        addStringCredential("azure-responses-key", "test-responses-key");
+
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        AtomicReference<String> apiKeyHeader = new AtomicReference<>();
+        AtomicReference<String> requestBody = new AtomicReference<>();
+
+        server.createContext("/openai/deployments/gpt-5-pro/responses", new JsonHandler(exchange -> {
+            requestPath.set(exchange.getRequestURI().toString());
+            apiKeyHeader.set(exchange.getRequestHeaders().getFirst("api-key"));
+            requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            return """
+                    {
+                      "output": [
+                        {
+                          "type": "message",
+                          "role": "assistant",
+                          "content": [
+                            {
+                              "type": "output_text",
+                              "text": "{\\"errorSummary\\":\\"Responses API test worked\\",\\"resolutionSteps\\":[\\"Verify deployment\\"],\\"bestPractices\\":[\\"Use latest API\\"],\\"errorSignature\\":\\"FAILURE: responses path verified\\"}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """;
+        }));
+
+        String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+        AzureOpenAIProvider provider = new AzureOpenAIProvider(
+                endpoint,
+                "gpt-5-pro",
+                "2025-02-01-preview",
+                "azure-responses-key",
+                AzureOpenAIProvider.ApiType.RESPONSES);
+
+        String explanation = provider.explainError("FAILURE: responses test", null, "English", null);
+
+        assertEquals("/openai/deployments/gpt-5-pro/responses?api-version=2025-02-01-preview",
+                requestPath.get());
+        assertEquals("test-responses-key", apiKeyHeader.get());
+
+        JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
+        assertNotNull(payload.path("input"));
+        assertTrue(requestBody.get().contains("Return ONLY valid JSON"));
+        assertTrue(explanation.contains("Responses API test worked"));
+        assertTrue(explanation.contains("Verify deployment"));
+    }
+
+    @Test
+    void fixAssistantUsesAzureChatCompletionsEndpoint(JenkinsRule jenkins) throws Exception {
         addStringCredential("azure-fix-key", "fix-key");
 
         AtomicReference<String> requestPath = new AtomicReference<>();
@@ -117,7 +170,8 @@ class AzureOpenAIProviderTest {
                 endpoint,
                 "fix-deployment",
                 "2025-02-01-preview",
-                "azure-fix-key");
+                "azure-fix-key",
+                AzureOpenAIProvider.ApiType.CHAT_COMPLETIONS);
 
         FixAssistant assistant = provider.createFixAssistant();
         String result = assistant.suggestFix("FAILURE: job failed");
@@ -126,6 +180,87 @@ class AzureOpenAIProviderTest {
                 requestPath.get());
         assertTrue(requestBody.get().contains("\"Jenkins build failed. Analyze and suggest a fix."));
         assertTrue(result.contains("\"fixable\":true"));
+    }
+
+    @Test
+    void fixAssistantUsesAzureResponsesEndpoint(JenkinsRule jenkins) throws Exception {
+        addStringCredential("azure-fix-responses-key", "fix-responses-key");
+
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        AtomicReference<String> requestBody = new AtomicReference<>();
+
+        server.createContext("/openai/deployments/gpt-5-fix/responses", new JsonHandler(exchange -> {
+            requestPath.set(exchange.getRequestURI().toString());
+            requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            return """
+                    {
+                      "output": [
+                        {
+                          "type": "message",
+                          "role": "assistant",
+                          "content": [
+                            {
+                              "type": "output_text",
+                              "text": "{\\"fixable\\":false,\\"explanation\\":\\"Cannot determine root cause\\",\\"confidence\\":\\"low\\",\\"fixType\\":\\"unknown\\",\\"changes\\":[]}"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """;
+        }));
+
+        String endpoint = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+        AzureOpenAIProvider provider = new AzureOpenAIProvider(
+                endpoint,
+                "gpt-5-fix",
+                "2025-03-01-preview",
+                "azure-fix-responses-key",
+                AzureOpenAIProvider.ApiType.RESPONSES);
+
+        FixAssistant assistant = provider.createFixAssistant();
+        String result = assistant.suggestFix("FAILURE: obscure error");
+
+        assertEquals("/openai/deployments/gpt-5-fix/responses?api-version=2025-03-01-preview",
+                requestPath.get());
+        assertTrue(result.contains("\"fixable\":false"));
+        assertTrue(result.contains("Cannot determine root cause"));
+    }
+
+    @Test
+    void apiTypeDefaultsToChatCompletionsWhenNull(JenkinsRule jenkins) throws Exception {
+        addStringCredential("azure-default-key", "default-key");
+
+        AtomicReference<String> requestPath = new AtomicReference<>();
+
+        server.createContext("/openai/deployments/default-gpt/chat/completions", new JsonHandler(exchange -> {
+            requestPath.set(exchange.getRequestURI().toString());
+            return """
+                    {
+                      "choices": [
+                        {
+                          "message": {
+                            "content": "{\\"errorSummary\\":\\"Default test passed\\",\\"resolutionSteps\\":[\\"Step 1\\"],\\"bestPractices\\":[],\\"errorSignature\\":\\"test\\"}"
+                          }
+                        }
+                      ]
+                    }
+                    """;
+        }));
+
+        String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+        // Pass null ApiType — should default to CHAT_COMPLETIONS
+        AzureOpenAIProvider provider = new AzureOpenAIProvider(
+                endpoint,
+                "default-gpt",
+                "2025-01-01-preview",
+                "azure-default-key",
+                null);
+
+        provider.explainError("test error", null, "English", null);
+
+        assertTrue(requestPath.get().contains("/chat/completions"),
+                "Should default to Chat Completions when ApiType is null");
     }
 
     private void addStringCredential(String id, String secret) throws IOException {

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
@@ -1,7 +1,9 @@
 package io.jenkins.plugins.explain_error.provider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -11,12 +13,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
+import io.jenkins.plugins.explain_error.ExplanationException;
 import io.jenkins.plugins.explain_error.autofix.FixAssistant;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.jupiter.api.AfterEach;
@@ -125,18 +131,20 @@ class AzureOpenAIProviderTest {
         AzureOpenAIProvider provider = new AzureOpenAIProvider(
                 endpoint,
                 "gpt-5-pro",
-                "2025-02-01-preview",
+                AzureOpenAIProvider.RESPONSES_MIN_API_VERSION,
                 "azure-responses-key",
                 AzureOpenAIProvider.ApiType.RESPONSES);
 
         String explanation = provider.explainError("FAILURE: responses test", null, "English", null);
 
-        assertEquals("/openai/responses?api-version=2025-02-01-preview",
+        assertEquals("/openai/responses?api-version=" + AzureOpenAIProvider.RESPONSES_MIN_API_VERSION,
                 requestPath.get());
         assertEquals("test-responses-key", apiKeyHeader.get());
 
         JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
         assertEquals("gpt-5-pro", payload.path("model").asText());
+        assertTrue(payload.has("store"));
+        assertFalse(payload.path("store").asBoolean(true));
         assertNotNull(payload.path("input"));
         assertTrue(requestBody.get().contains("Return ONLY valid JSON"));
         assertTrue(explanation.contains("Responses API test worked"));
@@ -215,20 +223,72 @@ class AzureOpenAIProviderTest {
         AzureOpenAIProvider provider = new AzureOpenAIProvider(
                 endpoint,
                 "gpt-5-fix",
-                "2025-03-01-preview",
+                AzureOpenAIProvider.RESPONSES_MIN_API_VERSION,
                 "azure-fix-responses-key",
                 AzureOpenAIProvider.ApiType.RESPONSES);
 
         FixAssistant assistant = provider.createFixAssistant();
         String result = assistant.suggestFix("FAILURE: obscure error");
 
-        assertEquals("/openai/responses?api-version=2025-03-01-preview",
+        assertEquals("/openai/responses?api-version=" + AzureOpenAIProvider.RESPONSES_MIN_API_VERSION,
                 requestPath.get());
 
         JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
         assertEquals("gpt-5-fix", payload.path("model").asText());
+        assertTrue(payload.has("store"));
+        assertFalse(payload.path("store").asBoolean(true));
         assertTrue(result.contains("\"fixable\":false"));
         assertTrue(result.contains("Cannot determine root cause"));
+    }
+
+    @Test
+    void descriptorRejectsUnsupportedResponsesApiVersion() {
+        AzureOpenAIProvider.DescriptorImpl descriptor = new AzureOpenAIProvider.DescriptorImpl();
+
+        FormValidation validation = descriptor.doCheckApiVersion(
+                "2025-01-01-preview",
+                AzureOpenAIProvider.ApiType.RESPONSES.name());
+
+        assertEquals(FormValidation.Kind.ERROR, validation.kind);
+        assertTrue(validation.getMessage().contains(AzureOpenAIProvider.RESPONSES_MIN_API_VERSION));
+    }
+
+    @Test
+    void descriptorListsApiTypeOptionsWithLabels() {
+        AzureOpenAIProvider.DescriptorImpl descriptor = new AzureOpenAIProvider.DescriptorImpl();
+
+        ListBoxModel items = descriptor.doFillApiTypeItems();
+
+        assertEquals(2, items.size());
+        assertEquals("Chat Completions API", items.get(0).name);
+        assertEquals(AzureOpenAIProvider.ApiType.CHAT_COMPLETIONS.name(), items.get(0).value);
+        assertEquals("Responses API", items.get(1).name);
+        assertEquals(AzureOpenAIProvider.ApiType.RESPONSES.name(), items.get(1).value);
+    }
+
+    @Test
+    void responsesApiRejectsUnsupportedApiVersionBeforeRequest(JenkinsRule jenkins) throws Exception {
+        addStringCredential("azure-old-responses-key", "old-responses-key");
+        AtomicInteger requests = new AtomicInteger();
+
+        server.createContext("/openai/responses", new JsonHandler(exchange -> {
+            requests.incrementAndGet();
+            return "{}";
+        }));
+
+        String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+        AzureOpenAIProvider provider = new AzureOpenAIProvider(
+                endpoint,
+                "gpt-5-pro",
+                "2025-01-01-preview",
+                "azure-old-responses-key",
+                AzureOpenAIProvider.ApiType.RESPONSES);
+
+        ExplanationException result = assertThrows(ExplanationException.class,
+                () -> provider.explainError("FAILURE: responses test", null, "English", null));
+
+        assertEquals("The provider is not properly configured.", result.getMessage());
+        assertEquals(0, requests.get());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
@@ -99,7 +99,7 @@ class AzureOpenAIProviderTest {
         AtomicReference<String> apiKeyHeader = new AtomicReference<>();
         AtomicReference<String> requestBody = new AtomicReference<>();
 
-        server.createContext("/openai/deployments/gpt-5-pro/responses", new JsonHandler(exchange -> {
+        server.createContext("/openai/responses", new JsonHandler(exchange -> {
             requestPath.set(exchange.getRequestURI().toString());
             apiKeyHeader.set(exchange.getRequestHeaders().getFirst("api-key"));
             requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
@@ -131,11 +131,12 @@ class AzureOpenAIProviderTest {
 
         String explanation = provider.explainError("FAILURE: responses test", null, "English", null);
 
-        assertEquals("/openai/deployments/gpt-5-pro/responses?api-version=2025-02-01-preview",
+        assertEquals("/openai/responses?api-version=2025-02-01-preview",
                 requestPath.get());
         assertEquals("test-responses-key", apiKeyHeader.get());
 
         JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
+        assertEquals("gpt-5-pro", payload.path("model").asText());
         assertNotNull(payload.path("input"));
         assertTrue(requestBody.get().contains("Return ONLY valid JSON"));
         assertTrue(explanation.contains("Responses API test worked"));
@@ -189,7 +190,7 @@ class AzureOpenAIProviderTest {
         AtomicReference<String> requestPath = new AtomicReference<>();
         AtomicReference<String> requestBody = new AtomicReference<>();
 
-        server.createContext("/openai/deployments/gpt-5-fix/responses", new JsonHandler(exchange -> {
+        server.createContext("/openai/responses", new JsonHandler(exchange -> {
             requestPath.set(exchange.getRequestURI().toString());
             requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
             return """
@@ -221,8 +222,11 @@ class AzureOpenAIProviderTest {
         FixAssistant assistant = provider.createFixAssistant();
         String result = assistant.suggestFix("FAILURE: obscure error");
 
-        assertEquals("/openai/deployments/gpt-5-fix/responses?api-version=2025-03-01-preview",
+        assertEquals("/openai/responses?api-version=2025-03-01-preview",
                 requestPath.get());
+
+        JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
+        assertEquals("gpt-5-fix", payload.path("model").asText());
         assertTrue(result.contains("\"fixable\":false"));
         assertTrue(result.contains("Cannot determine root cause"));
     }

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.explain_error.provider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -343,6 +344,33 @@ class AzureOpenAIProviderTest {
 
         assertEquals("/openai/v1/responses", requestPath.get());
         assertTrue(result.contains("Top-level output_text worked"));
+    }
+
+    @Test
+    void responsesApiHandlesErrorResponse(JenkinsRule jenkins) throws Exception {
+        addStringCredential("azure-error-key", "error-key");
+
+        server.createContext("/openai/v1/responses", new JsonHandler(exchange -> {
+            return """
+                    {
+                      "error": {
+                        "message": "Deployment not found"
+                      }
+                    }
+                    """;
+        }));
+
+        String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+        AzureOpenAIProvider provider = new AzureOpenAIProvider(
+                endpoint,
+                "gpt-5-pro",
+                "2025-01-01-preview",
+                "azure-error-key",
+                AzureOpenAIProvider.ApiType.RESPONSES);
+
+        ExplanationException ex = assertThrows(ExplanationException.class,
+                () -> provider.explainError("FAILURE: error test", null, "English", null));
+        assertTrue(ex.getMessage().contains("Deployment not found"));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
@@ -142,6 +142,8 @@ class AzureOpenAIProviderTest {
         JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
         assertEquals("gpt-5-pro", payload.path("model").asText());
         assertEquals(1000, payload.path("max_output_tokens").asInt());
+        assertEquals("minimal", payload.path("reasoning").path("effort").asText());
+        assertEquals("low", payload.path("text").path("verbosity").asText());
         assertTrue(payload.has("store"));
         assertFalse(payload.path("store").asBoolean(true));
         assertNotNull(payload.path("input"));
@@ -236,6 +238,8 @@ class AzureOpenAIProviderTest {
         JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
         assertEquals("gpt-5-fix", payload.path("model").asText());
         assertEquals(2000, payload.path("max_output_tokens").asInt());
+        assertEquals("minimal", payload.path("reasoning").path("effort").asText());
+        assertEquals("low", payload.path("text").path("verbosity").asText());
         assertTrue(payload.has("store"));
         assertFalse(payload.path("store").asBoolean(true));
         assertTrue(result.contains("\"fixable\":false"));
@@ -307,8 +311,38 @@ class AzureOpenAIProviderTest {
         JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
         assertEquals("gpt-5-pro", payload.path("model").asText());
         assertEquals(32, payload.path("max_output_tokens").asInt());
+        assertEquals("minimal", payload.path("reasoning").path("effort").asText());
+        assertEquals("low", payload.path("text").path("verbosity").asText());
         assertEquals("Test the connection.", payload.path("input").asText());
         assertFalse(requestBody.get().contains("Return ONLY valid JSON"));
+    }
+
+    @Test
+    void responsesApiParsesTopLevelOutputText(JenkinsRule jenkins) throws Exception {
+        addStringCredential("azure-output-text-key", "output-text-key");
+        AtomicReference<String> requestPath = new AtomicReference<>();
+
+        server.createContext("/openai/v1/responses", new JsonHandler(exchange -> {
+            requestPath.set(exchange.getRequestURI().toString());
+            return """
+                    {
+                      "output_text": "{\\"errorSummary\\":\\"Top-level output_text worked\\"}"
+                    }
+                    """;
+        }));
+
+        String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+        AzureOpenAIProvider provider = new AzureOpenAIProvider(
+                endpoint,
+                "gpt-5-pro",
+                "2025-01-01-preview",
+                "azure-output-text-key",
+                AzureOpenAIProvider.ApiType.RESPONSES);
+
+        String result = provider.explainError("FAILURE: responses test", null, "English", null);
+
+        assertEquals("/openai/v1/responses", requestPath.get());
+        assertTrue(result.contains("Top-level output_text worked"));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/ProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/ProviderTest.java
@@ -292,7 +292,7 @@ class ProviderTest {
 
     @Test
     void testAzureOpenAiNullEndpoint() {
-        BaseAIProvider provider = new AzureOpenAIProvider(null, "deployment", "2025-01-01-preview", "credentials-id");
+        BaseAIProvider provider = new AzureOpenAIProvider(null, "deployment", "2025-01-01-preview", "credentials-id", null);
         ExplanationException result = assertThrows(ExplanationException.class,
                 () -> provider.explainError("Test error", null));
 
@@ -302,7 +302,7 @@ class ProviderTest {
     @Test
     void testAzureOpenAiNullDeployment() {
         BaseAIProvider provider = new AzureOpenAIProvider("https://resource.openai.azure.com", null,
-                "2025-01-01-preview", "credentials-id");
+                "2025-01-01-preview", "credentials-id", null);
         ExplanationException result = assertThrows(ExplanationException.class,
                 () -> provider.explainError("Test error", null));
 
@@ -312,7 +312,7 @@ class ProviderTest {
     @Test
     void testAzureOpenAiNullApiVersion() {
         BaseAIProvider provider = new AzureOpenAIProvider("https://resource.openai.azure.com", "deployment",
-                null, "credentials-id");
+                null, "credentials-id", null);
         ExplanationException result = assertThrows(ExplanationException.class,
                 () -> provider.explainError("Test error", null));
 
@@ -322,7 +322,7 @@ class ProviderTest {
     @Test
     void testAzureOpenAiNullCredentialsId() {
         BaseAIProvider provider = new AzureOpenAIProvider("https://resource.openai.azure.com", "deployment",
-                "2025-01-01-preview", null);
+                "2025-01-01-preview", null, null);
         ExplanationException result = assertThrows(ExplanationException.class,
                 () -> provider.explainError("Test error", null));
 

--- a/src/test/resources/io/jenkins/plugins/explain_error/casc_azure_openai.yaml
+++ b/src/test/resources/io/jenkins/plugins/explain_error/casc_azure_openai.yaml
@@ -14,5 +14,5 @@ unclassified:
         deployment: "gpt-4o-enterprise"
         apiVersion: "2025-01-01-preview"
         credentialsId: "azure-openai-key"
-        # apiType: "CHAT_COMPLETIONS" # Optional, defaults to CHAT_COMPLETIONS. RESPONSES requires apiVersion 2025-04-01-preview or later.
+        # apiType: "CHAT_COMPLETIONS" # Optional, defaults to CHAT_COMPLETIONS. RESPONSES uses /openai/v1/responses.
     enableExplanation: true

--- a/src/test/resources/io/jenkins/plugins/explain_error/casc_azure_openai.yaml
+++ b/src/test/resources/io/jenkins/plugins/explain_error/casc_azure_openai.yaml
@@ -14,4 +14,5 @@ unclassified:
         deployment: "gpt-4o-enterprise"
         apiVersion: "2025-01-01-preview"
         credentialsId: "azure-openai-key"
+        # apiType: "CHAT_COMPLETIONS" # Optional, defaults to CHAT_COMPLETIONS. Use RESPONSES for newer models.
     enableExplanation: true

--- a/src/test/resources/io/jenkins/plugins/explain_error/casc_azure_openai.yaml
+++ b/src/test/resources/io/jenkins/plugins/explain_error/casc_azure_openai.yaml
@@ -14,5 +14,5 @@ unclassified:
         deployment: "gpt-4o-enterprise"
         apiVersion: "2025-01-01-preview"
         credentialsId: "azure-openai-key"
-        # apiType: "CHAT_COMPLETIONS" # Optional, defaults to CHAT_COMPLETIONS. Use RESPONSES for newer models.
+        # apiType: "CHAT_COMPLETIONS" # Optional, defaults to CHAT_COMPLETIONS. RESPONSES requires apiVersion 2025-04-01-preview or later.
     enableExplanation: true


### PR DESCRIPTION
## Summary

Add support for the Azure OpenAI **Responses API** (`/responses`) endpoint, enabling compatibility with newer models (e.g. gpt-5.x) that do not support the legacy `/chat/completions` API.

Resolves #172.

## Changes

- **`AzureOpenAIProvider`**: Added `ApiType` enum (`CHAT_COMPLETIONS` / `RESPONSES`) and `apiType` field
  - Backward compatible: `null` defaults to `CHAT_COMPLETIONS` for existing configurations
  - Builds correct URI (`/responses` vs `/chat/completions`), request body (`input` vs `messages` array), and response parsing (`output[].content[].text` vs `choices[].message.content`) for each API type
- **`config.jelly`**: Added API Type dropdown in the provider configuration UI
- **Tests**: Added 5 new tests covering both API types for explain/fix assistants plus null-default backward compatibility

## Testing

- `AzureOpenAIProviderTest`: 5/5 passed
- `ProviderTest`: 42/42 passed
- `GlobalConfigurationImplTest` + `ExplainErrorFolderPropertyTest`: 28/28 passed
- `make build` and `make lint`: passed