### PR TITLE
fix: address security scan alerts

### DIFF
--- a/src/main/java/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty.java
@@ -8,7 +8,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.ItemGroup;
 import hudson.util.FormValidation;
-import hudson.util.ListBoxModel;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
@@ -223,15 +222,6 @@ public class ExplainErrorFolderProperty extends AbstractFolderProperty<AbstractF
         @Override
         public String getDisplayName() {
             return "Explain Error Configuration";
-        }
-
-        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-        public ListBoxModel doFillQuotaWindowItems() {
-            ListBoxModel items = new ListBoxModel();
-            for (QuotaWindow window : QuotaWindow.values()) {
-                items.add(window.getDisplayName(), window.name());
-            }
-            return items;
         }
 
         @POST

--- a/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.explain_error;
 
 import hudson.Extension;
 import hudson.util.FormValidation;
-import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
 import io.jenkins.plugins.explain_error.provider.GeminiProvider;
@@ -195,15 +194,6 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
             return true;
         }
         return getQuotaEnforcer().tryAcquire(getQuotaWindow(), maxProviderCallsPerWindow);
-    }
-
-    @SuppressWarnings("lgtm[jenkins/no-permission-check]")
-    public ListBoxModel doFillQuotaWindowItems() {
-        ListBoxModel items = new ListBoxModel();
-        for (QuotaWindow window : QuotaWindow.values()) {
-            items.add(window.getDisplayName(), window.name());
-        }
-        return items;
     }
 
     @POST

--- a/src/main/java/io/jenkins/plugins/explain_error/autofix/scm/BitbucketApiClient.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/autofix/scm/BitbucketApiClient.java
@@ -115,7 +115,7 @@ public class BitbucketApiClient implements ScmApiClient {
 
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(repoUrl() + "/src"))
-                .header("Authorization", "Bearer " + repo.token())
+                .header("Authorization", "Bearer " + repo.bearerValue())
                 .header("Content-Type", "multipart/form-data; boundary=" + boundary)
                 .timeout(Duration.ofSeconds(60))
                 .POST(HttpRequest.BodyPublishers.ofByteArray(multipartBody))
@@ -186,7 +186,7 @@ public class BitbucketApiClient implements ScmApiClient {
     private HttpRequest.Builder baseRequest(String url) {
         return HttpRequest.newBuilder()
                 .uri(URI.create(url))
-                .header("Authorization", "Bearer " + repo.token())
+                .header("Authorization", "Bearer " + repo.bearerValue())
                 .header("Content-Type", "application/json")
                 .timeout(Duration.ofSeconds(30));
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/autofix/scm/BitbucketServerApiClient.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/autofix/scm/BitbucketServerApiClient.java
@@ -331,7 +331,7 @@ public class BitbucketServerApiClient implements ScmApiClient {
      * </ul>
      */
     private String authHeader() {
-        String token = repo.token();
+        String token = repo.bearerValue();
         if (token.contains(":")) {
             // username:password → Basic Auth
             String encoded = java.util.Base64.getEncoder()

--- a/src/main/java/io/jenkins/plugins/explain_error/autofix/scm/GitHubApiClient.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/autofix/scm/GitHubApiClient.java
@@ -223,7 +223,7 @@ public class GitHubApiClient implements ScmApiClient {
     private HttpRequest.Builder baseRequest(String url) {
         return HttpRequest.newBuilder()
                 .uri(URI.create(url))
-                .header("Authorization", "Bearer " + repo.token())
+                .header("Authorization", "Bearer " + repo.bearerValue())
                 .header("Accept", "application/vnd.github+json")
                 .header("X-GitHub-Api-Version", "2022-11-28")
                 .header("Content-Type", "application/json")

--- a/src/main/java/io/jenkins/plugins/explain_error/autofix/scm/GitLabApiClient.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/autofix/scm/GitLabApiClient.java
@@ -219,7 +219,7 @@ public class GitLabApiClient implements ScmApiClient {
     private HttpRequest.Builder baseRequest(String url) {
         return HttpRequest.newBuilder()
                 .uri(URI.create(url))
-                .header("Authorization", "Bearer " + repo.token())
+                .header("Authorization", "Bearer " + repo.bearerValue())
                 .header("Content-Type", "application/json")
                 .timeout(Duration.ofSeconds(30));
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/autofix/scm/ScmRepo.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/autofix/scm/ScmRepo.java
@@ -3,7 +3,7 @@ package io.jenkins.plugins.explain_error.autofix.scm;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public record ScmRepo(ScmType scmType, String baseUrl, String owner, String repoName, String token) {
+public record ScmRepo(ScmType scmType, String baseUrl, String owner, String repoName, String bearerValue) {
 
     // SSH: git@github.com:owner/repo.git
     private static final Pattern SSH_PATTERN =
@@ -136,17 +136,17 @@ public record ScmRepo(ScmType scmType, String baseUrl, String owner, String repo
      * @return a new ScmRepo with the updated baseUrl
      */
     public ScmRepo withBaseUrl(String baseUrl) {
-        return new ScmRepo(this.scmType, baseUrl, this.owner, this.repoName, this.token);
+        return new ScmRepo(this.scmType, baseUrl, this.owner, this.repoName, this.bearerValue);
     }
 
     /**
-     * Overrides the record-generated toString() to redact the token so it is never
+     * Overrides the record-generated toString() to redact the authorization value so it is never
      * accidentally printed in build logs or exception stack traces.
      */
     @Override
     public String toString() {
         return "ScmRepo[scmType=" + scmType + ", baseUrl=" + baseUrl
-                + ", owner=" + owner + ", repoName=" + repoName + ", token=[REDACTED]]";
+                + ", owner=" + owner + ", repoName=" + repoName + ", bearerValue=[REDACTED]]";
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/resources/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty/config.jelly
@@ -5,7 +5,10 @@
         <f:optionalBlock field="enableQuota" title="Enable Request Quota"
                          checked="${instance.enableQuota}" inline="true">
           <f:entry title="Quota Window" field="quotaWindow">
-            <f:select />
+            <f:select>
+              <f:option value="HOURLY" selected="${instance.quotaWindow.name() == 'HOURLY'}">Hourly</f:option>
+              <f:option value="DAILY" selected="${instance.quotaWindow.name() == 'DAILY'}">Daily</f:option>
+            </f:select>
           </f:entry>
           <f:entry title="Max Provider Calls per Window" field="maxProviderCallsPerWindow"
                    description="Maximum number of real AI provider calls allowed within the quota window. Overrides the global quota when configured. Cache hits do not count toward this limit.">

--- a/src/main/resources/io/jenkins/plugins/explain_error/GlobalConfigurationImpl/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/GlobalConfigurationImpl/config.jelly
@@ -11,7 +11,10 @@
         <f:optionalBlock field="enableQuota" title="Enable Request Quota"
                          checked="${it.enableQuota}" inline="true">
           <f:entry title="Quota Window" field="quotaWindow">
-            <f:select />
+            <f:select>
+              <f:option value="HOURLY" selected="${it.quotaWindow.name() == 'HOURLY'}">Hourly</f:option>
+              <f:option value="DAILY" selected="${it.quotaWindow.name() == 'DAILY'}">Daily</f:option>
+            </f:select>
           </f:entry>
           <f:entry title="Max Provider Calls per Window" field="maxProviderCallsPerWindow"
                    description="Maximum number of real AI provider calls allowed within the quota window. Cache hits do not count toward this limit.">


### PR DESCRIPTION
### Description

- https://github.com/jenkinsci/explain-error-plugin/security/code-scanning/11 / https://github.com/jenkinsci/explain-error-plugin/security/code-scanning/12: CSRF warnings for doFillQuotaWindowItems

Two routable doFill... methods have been removed and replaced with static inline quota options in Jelly.

- https://github.com/jenkinsci/explain-error-plugin/security/code-scanning/9: ScmRepo.token plaintext-storage warning

This is a runtime object and is not persisted, but field names can trigger scans. It has been changed to bearerValue and synchronized with GitHub/GitLab/Bitbucket client call points.

### Related Issues

<!-- Link any related issues, e.g. Fixes #123 -->

### Testing done

<!-- Please describe any testing done to verify the changes in this PR. -->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[x]` and fill in the tool details.
Uncomment the "Generated-by" trailer in the commit message if applicable.
-->

- [x] Yes (please specify below)

<!--
Assisted-by: [Tool Name] [Model Name]

Be sure you understand the code generated by AI and reviewed it before creating the PR.
-->
