### PR TITLE
Fix quota window dropdowns

### DIFF
--- a/src/main/java/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty.java
@@ -225,6 +225,7 @@ public class ExplainErrorFolderProperty extends AbstractFolderProperty<AbstractF
             return "Explain Error Configuration";
         }
 
+        @POST
         public ListBoxModel doFillQuotaWindowItems() {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             ListBoxModel items = new ListBoxModel();

--- a/src/main/java/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.ItemGroup;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
@@ -222,6 +223,15 @@ public class ExplainErrorFolderProperty extends AbstractFolderProperty<AbstractF
         @Override
         public String getDisplayName() {
             return "Explain Error Configuration";
+        }
+
+        public ListBoxModel doFillQuotaWindowItems() {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            ListBoxModel items = new ListBoxModel();
+            for (QuotaWindow value : QuotaWindow.values()) {
+                items.add(value.getDisplayName(), value.name());
+            }
+            return items;
         }
 
         @POST

--- a/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.explain_error;
 
 import hudson.Extension;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
 import io.jenkins.plugins.explain_error.provider.GeminiProvider;
@@ -194,6 +195,15 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
             return true;
         }
         return getQuotaEnforcer().tryAcquire(getQuotaWindow(), maxProviderCallsPerWindow);
+    }
+
+    public ListBoxModel doFillQuotaWindowItems() {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        ListBoxModel items = new ListBoxModel();
+        for (QuotaWindow value : QuotaWindow.values()) {
+            items.add(value.getDisplayName(), value.name());
+        }
+        return items;
     }
 
     @POST

--- a/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
@@ -197,6 +197,7 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
         return getQuotaEnforcer().tryAcquire(getQuotaWindow(), maxProviderCallsPerWindow);
     }
 
+    @POST
     public ListBoxModel doFillQuotaWindowItems() {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         ListBoxModel items = new ListBoxModel();

--- a/src/main/resources/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty/config.jelly
@@ -5,10 +5,7 @@
         <f:optionalBlock field="enableQuota" title="Enable Request Quota"
                          checked="${instance.enableQuota}" inline="true">
           <f:entry title="Quota Window" field="quotaWindow">
-            <f:select>
-              <f:option value="HOURLY" selected="${instance.quotaWindow.name() == 'HOURLY'}">Hourly</f:option>
-              <f:option value="DAILY" selected="${instance.quotaWindow.name() == 'DAILY'}">Daily</f:option>
-            </f:select>
+            <f:select />
           </f:entry>
           <f:entry title="Max Provider Calls per Window" field="maxProviderCallsPerWindow"
                    description="Maximum number of real AI provider calls allowed within the quota window. Overrides the global quota when configured. Cache hits do not count toward this limit.">

--- a/src/main/resources/io/jenkins/plugins/explain_error/GlobalConfigurationImpl/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/GlobalConfigurationImpl/config.jelly
@@ -11,10 +11,7 @@
         <f:optionalBlock field="enableQuota" title="Enable Request Quota"
                          checked="${it.enableQuota}" inline="true">
           <f:entry title="Quota Window" field="quotaWindow">
-            <f:select>
-              <f:option value="HOURLY" selected="${it.quotaWindow.name() == 'HOURLY'}">Hourly</f:option>
-              <f:option value="DAILY" selected="${it.quotaWindow.name() == 'DAILY'}">Daily</f:option>
-            </f:select>
+            <f:select />
           </f:entry>
           <f:entry title="Max Provider Calls per Window" field="maxProviderCallsPerWindow"
                    description="Maximum number of real AI provider calls allowed within the quota window. Cache hits do not count toward this limit.">

--- a/src/test/java/io/jenkins/plugins/explain_error/ExplainErrorFolderPropertyTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ExplainErrorFolderPropertyTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.explain_error;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import io.jenkins.plugins.explain_error.provider.AzureOpenAIProvider;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
@@ -201,5 +202,18 @@ class ExplainErrorFolderPropertyTest {
         AzureOpenAIProvider azure = (AzureOpenAIProvider) retrieved.getAiProvider();
         assertEquals("gpt-4o-enterprise", azure.getDeployment());
         assertEquals("azure-openai-key", azure.getCredentialsId());
+    }
+
+    @Test
+    void descriptorListsQuotaWindowOptions(JenkinsRule jenkins) {
+        ExplainErrorFolderProperty.DescriptorImpl descriptor = new ExplainErrorFolderProperty.DescriptorImpl();
+
+        ListBoxModel items = descriptor.doFillQuotaWindowItems();
+
+        assertEquals(2, items.size());
+        assertEquals("Hourly", items.get(0).name);
+        assertEquals(QuotaWindow.HOURLY.name(), items.get(0).value);
+        assertEquals("Daily", items.get(1).name);
+        assertEquals(QuotaWindow.DAILY.name(), items.get(1).value);
     }
 }

--- a/src/test/java/io/jenkins/plugins/explain_error/ExplainErrorFolderPropertyTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ExplainErrorFolderPropertyTest.java
@@ -206,7 +206,8 @@ class ExplainErrorFolderPropertyTest {
 
     @Test
     void descriptorListsQuotaWindowOptions(JenkinsRule jenkins) {
-        ExplainErrorFolderProperty.DescriptorImpl descriptor = new ExplainErrorFolderProperty.DescriptorImpl();
+        ExplainErrorFolderProperty.DescriptorImpl descriptor =
+                jenkins.jenkins.getDescriptorByType(ExplainErrorFolderProperty.DescriptorImpl.class);
 
         ListBoxModel items = descriptor.doFillQuotaWindowItems();
 

--- a/src/test/java/io/jenkins/plugins/explain_error/GlobalConfigurationImplTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/GlobalConfigurationImplTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
 
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import io.jenkins.plugins.explain_error.provider.AzureOpenAIProvider;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
@@ -216,6 +217,17 @@ class GlobalConfigurationImplTest {
         String displayName = config.getDisplayName();
         assertNotNull(displayName);
         assertEquals("Explain Error Plugin Configuration", displayName);
+    }
+
+    @Test
+    void descriptorListsQuotaWindowOptions() {
+        ListBoxModel items = config.doFillQuotaWindowItems();
+
+        assertEquals(2, items.size());
+        assertEquals("Hourly", items.get(0).name);
+        assertEquals(QuotaWindow.HOURLY.name(), items.get(0).value);
+        assertEquals("Daily", items.get(1).name);
+        assertEquals(QuotaWindow.DAILY.name(), items.get(1).value);
     }
 
     private List<String> providerDisplayNames() {


### PR DESCRIPTION
## Summary
- Add quota window fill methods for folder and global configuration descriptors
- Use descriptor-backed select controls for quota windows
- Add tests for Hourly and Daily quota window options

## Validation
- mvn -q -Dtest=ExplainErrorFolderPropertyTest,GlobalConfigurationImplTest test
- make lint

Fixes #182