### PR TITLE
feat: add pipeline graph view node explain entrypoint

### DIFF
--- a/src/main/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorAction.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorAction.java
@@ -181,6 +181,37 @@ public class ConsoleExplainErrorAction implements RunAction2 {
     }
 
     /**
+     * AJAX endpoint to retrieve a previously generated explanation for a Pipeline node.
+     * Only returns cached results; never triggers AI generation.
+     */
+    @RequirePOST
+    public void doGetNodeExplanation(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        String nodeId = req.getParameter("nodeId");
+        nodeId = nodeId != null ? nodeId.trim() : "";
+
+        try {
+            run.checkPermission(hudson.model.Item.READ);
+
+            if (nodeId.isEmpty()) {
+                writeJsonResponse(rsp, "warning", "Unknown", "No Pipeline node was selected.");
+                return;
+            }
+
+            StepErrorExplanationAction stepAction = run.getAction(StepErrorExplanationAction.class);
+            StepErrorExplanationAction.Entry entry = stepAction != null ? stepAction.getExplanation(nodeId) : null;
+            if (entry != null && entry.hasValidExplanation()) {
+                this.urlString = entry.getUrlString();
+                writeJsonResponse(rsp, "success", entry.getProviderName(), entry.getExplanation());
+            } else {
+                writeJsonResponse(rsp, "no_cache", "Unknown", "");
+            }
+        } catch (Exception e) {
+            LOGGER.warning("Error getting node explanation: " + e.getMessage());
+            writeJsonResponse(rsp, "error", "Unknown", "Error: " + e.getMessage());
+        }
+    }
+
+    /**
      * AJAX endpoint to check build status.
      * Returns JSON with buildingStatus to determine if button should be shown. 0 - SUCCESS, 1 - RUNNING, 2 - FINISHED and FAILURE
      */

--- a/src/main/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorAction.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorAction.java
@@ -1,6 +1,5 @@
 package io.jenkins.plugins.explain_error;
 
-import com.google.common.annotations.VisibleForTesting;
 import hudson.model.Result;
 import hudson.model.Run;
 import jenkins.model.RunAction2;
@@ -86,8 +85,8 @@ public class ConsoleExplainErrorAction implements RunAction2 {
             if (!forceNew && existingAction != null && existingAction.hasValidExplanation()) {
                 recordUsage(UsageEvent.Result.CACHE_HIT, existingAction.getProviderName(),
                         existingAction.getProviderModel(), startTimeNanos, existingAction.getInputLogLineCount());
-                // Return existing explanation with a flag indicating it's cached
-                writeJsonResponse(rsp, "success", existingAction.getProviderName(), createCachedResponse(existingAction.getExplanation()));
+                // Return existing explanation
+                writeJsonResponse(rsp, "success", existingAction.getProviderName(), existingAction.getExplanation());
                 return;
             }
 
@@ -143,8 +142,7 @@ public class ConsoleExplainErrorAction implements RunAction2 {
                 recordUsage(UsageEvent.EntryPoint.PIPELINE_GRAPH_NODE, UsageEvent.Result.CACHE_HIT,
                         existing.getProviderName(), existing.getProviderModel(), startTimeNanos,
                         existing.getInputLogLineCount());
-                writeJsonResponse(rsp, "success", existing.getProviderName(),
-                        createCachedResponse(existing.getExplanation()));
+                writeJsonResponse(rsp, "success", existing.getProviderName(), existing.getExplanation());
                 return;
             }
 
@@ -252,16 +250,6 @@ public class ConsoleExplainErrorAction implements RunAction2 {
         json.put("url", urlString);
         writer.write(json.toString());
         writer.flush();
-    }
-
-    /**
-     * Create a response indicating this is a cached result.
-     * @param explanation The cached explanation
-     * @return The response string with cached indicator
-     */
-    @VisibleForTesting
-    String createCachedResponse(String explanation) {
-        return explanation + "\n\n[Note: This is a previously generated explanation. Use the 'Generate New' option to create a new one.]";
     }
 
     public Run<?, ?> getRun() {

--- a/src/main/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorAction.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorAction.java
@@ -92,11 +92,7 @@ public class ConsoleExplainErrorAction implements RunAction2 {
             }
 
             // Optionally allow maxLines as a parameter, default to 200
-            int maxLines = 200;
-            String maxLinesParam = req.getParameter("maxLines");
-            if (maxLinesParam != null) {
-                try { maxLines = Integer.parseInt(maxLinesParam); } catch (NumberFormatException ignore) {}
-            }
+            int maxLines = parseMaxLines(req, 200);
 
             // Fetch the last N lines of the log
             PipelineLogExtractor logExtractor = new PipelineLogExtractor(run, maxLines, Jenkins.getAuthentication2(),
@@ -116,6 +112,70 @@ public class ConsoleExplainErrorAction implements RunAction2 {
         } catch (Exception e) {
             LOGGER.severe("=== EXPLAIN ERROR REQUEST FAILED ===");
             LOGGER.severe("Error explaining console error: " + e.getMessage());
+            writeJsonResponse(rsp, "error", "Unknown", "Error: " + e.getMessage());
+        }
+    }
+
+    /**
+     * AJAX endpoint to explain a selected Pipeline Graph View node.
+     */
+    @RequirePOST
+    public void doExplainNodeError(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        long startTimeNanos = System.nanoTime();
+        String nodeId = req.getParameter("nodeId");
+        nodeId = nodeId != null ? nodeId.trim() : "";
+
+        try {
+            run.checkPermission(hudson.model.Item.READ);
+
+            if (nodeId.isEmpty()) {
+                recordUsage(UsageEvent.EntryPoint.PIPELINE_GRAPH_NODE, UsageEvent.Result.DISABLED,
+                        null, null, startTimeNanos, 0);
+                writeJsonResponse(rsp, "warning", "Unknown", "No Pipeline node was selected.");
+                return;
+            }
+
+            boolean forceNew = "true".equals(req.getParameter("forceNew"));
+            StepErrorExplanationAction stepAction = run.getAction(StepErrorExplanationAction.class);
+            StepErrorExplanationAction.Entry existing = stepAction != null ? stepAction.getExplanation(nodeId) : null;
+            if (!forceNew && existing != null && existing.hasValidExplanation()) {
+                this.urlString = existing.getUrlString();
+                recordUsage(UsageEvent.EntryPoint.PIPELINE_GRAPH_NODE, UsageEvent.Result.CACHE_HIT,
+                        existing.getProviderName(), existing.getProviderModel(), startTimeNanos,
+                        existing.getInputLogLineCount());
+                writeJsonResponse(rsp, "success", existing.getProviderName(),
+                        createCachedResponse(existing.getExplanation()));
+                return;
+            }
+
+            int maxLines = parseMaxLines(req, 200);
+            PipelineLogExtractor logExtractor = new PipelineLogExtractor(run, maxLines, Jenkins.getAuthentication2(),
+                    false, null);
+            PipelineLogExtractor.ExtractionResult extractionResult = logExtractor.extractNodeLog(nodeId);
+            this.urlString = extractionResult.url();
+            if (extractionResult.logLines().isEmpty()) {
+                recordUsage(UsageEvent.EntryPoint.PIPELINE_GRAPH_NODE, UsageEvent.Result.DISABLED,
+                        null, null, startTimeNanos, 0);
+                writeJsonResponse(rsp, "warning", "Unknown",
+                        "No log output found for the selected Pipeline node.");
+                return;
+            }
+
+            String errorText = String.join("\n", extractionResult.logLines());
+            ErrorExplainer explainer = new ErrorExplainer();
+            try {
+                ErrorExplanationAction explanation = explainer.explainErrorText(errorText, urlString, run,
+                        UsageEvent.EntryPoint.PIPELINE_GRAPH_NODE, false);
+                StepErrorExplanationAction cacheAction = getOrCreateStepAction();
+                cacheAction.putExplanation(nodeId, explanation);
+                run.save();
+                writeJsonResponse(rsp, "success", explanation.getProviderName(), explanation.getExplanation());
+            } catch (ExplanationException ee) {
+                writeJsonResponse(rsp, ee.getLevel(), explainer.getProviderName(), ee.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.severe("=== EXPLAIN PIPELINE NODE REQUEST FAILED ===");
+            LOGGER.severe("Error explaining pipeline node: " + e.getMessage());
             writeJsonResponse(rsp, "error", "Unknown", "Error: " + e.getMessage());
         }
     }
@@ -183,14 +243,43 @@ public class ConsoleExplainErrorAction implements RunAction2 {
 
     private void recordUsage(UsageEvent.Result result, String providerName, String model,
                              long startTimeNanos, int inputLogLineCount) {
+        recordUsage(UsageEvent.EntryPoint.CONSOLE_ACTION, result, providerName, model,
+                startTimeNanos, inputLogLineCount);
+    }
+
+    private void recordUsage(UsageEvent.EntryPoint entryPoint, UsageEvent.Result result, String providerName,
+                             String model, long startTimeNanos, int inputLogLineCount) {
         UsageRecorders.get().record(new UsageEvent(
                 System.currentTimeMillis(),
-                UsageEvent.EntryPoint.CONSOLE_ACTION,
+                entryPoint,
                 result,
                 providerName,
                 model,
                 Math.max(0L, (System.nanoTime() - startTimeNanos) / 1_000_000L),
                 inputLogLineCount,
                 false));
+    }
+
+    private StepErrorExplanationAction getOrCreateStepAction() {
+        StepErrorExplanationAction action = run.getAction(StepErrorExplanationAction.class);
+        if (action != null) {
+            return action;
+        }
+        action = new StepErrorExplanationAction();
+        run.addAction(action);
+        return action;
+    }
+
+    private int parseMaxLines(StaplerRequest2 req, int defaultValue) {
+        String maxLinesParam = req.getParameter("maxLines");
+        if (maxLinesParam == null) {
+            return defaultValue;
+        }
+        try {
+            int value = Integer.parseInt(maxLinesParam);
+            return value > 0 ? value : defaultValue;
+        } catch (NumberFormatException ignore) {
+            return defaultValue;
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorAction.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorAction.java
@@ -189,15 +189,11 @@ public class ConsoleExplainErrorAction implements RunAction2 {
         try {
             run.checkPermission(hudson.model.Item.READ);
 
-            Integer buildingStatus = run.isBuilding() ? 1 : 0;
-
-            if (buildingStatus == 0) {
-                Result result = run.getResult();
-                if (result == Result.SUCCESS) {
-                    buildingStatus = 0;
-                } else {
-                    buildingStatus = 2;
-                }
+            int buildingStatus = 0;
+            if (run.isBuilding()) {
+                buildingStatus = 1;
+            } else if (run.getResult() == Result.FAILURE) {
+                buildingStatus = 2;
             }
 
             rsp.setContentType("application/json");

--- a/src/main/java/io/jenkins/plugins/explain_error/ConsolePageDecorator.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ConsolePageDecorator.java
@@ -53,7 +53,11 @@ public class ConsolePageDecorator extends PageDecorator {
 
     public boolean isPipelineGraphViewPage() {
         String uri = Stapler.getCurrentRequest2().getRequestURI();
-        return uri.matches(".*/stages/?$") && Jenkins.get().getPlugin("pipeline-graph-view") != null;
+        return isPipelineGraphViewUri(uri) && Jenkins.get().getPlugin("pipeline-graph-view") != null;
+    }
+
+    static boolean isPipelineGraphViewUri(String uri) {
+        return uri != null && uri.matches(".*/(stages|pipeline-overview)/?$");
     }
 
     public String getRunUrl() {

--- a/src/main/java/io/jenkins/plugins/explain_error/ConsolePageDecorator.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ConsolePageDecorator.java
@@ -69,7 +69,15 @@ public class ConsolePageDecorator extends PageDecorator {
         }
     }
 
+    /**
+     * Returns the console-level explanation for pre-populating the Jelly view.
+     * Only relevant on console pages; returns null on graph view pages because
+     * graph view uses per-node {@link StepErrorExplanationAction} explanations.
+     */
     public ErrorExplanationAction getExistingExplanation() {
+        if (isPipelineGraphViewPage()) {
+            return null;
+        }
         Ancestor ancestor = Stapler.getCurrentRequest2().findAncestor(Run.class);
         if (ancestor != null && ancestor.getObject() instanceof Run<?, ?> run) {
             return run.getAction(ErrorExplanationAction.class);

--- a/src/main/java/io/jenkins/plugins/explain_error/ConsolePageDecorator.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ConsolePageDecorator.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.explain_error;
 import hudson.Extension;
 import hudson.model.PageDecorator;
 import hudson.model.Run;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
 
@@ -39,11 +40,20 @@ public class ConsolePageDecorator extends PageDecorator {
     }
 
     /**
-     * Helper method used by jelly to checked if we're on a console url.
+     * Helper method used by jelly to check if we're on a supported build page.
      */
     public boolean isPluginActive() {
+        return isConsolePage() || isPipelineGraphViewPage();
+    }
+
+    public boolean isConsolePage() {
         String uri = Stapler.getCurrentRequest2().getRequestURI();
         return uri.matches(".*/console(Full)?$");
+    }
+
+    public boolean isPipelineGraphViewPage() {
+        String uri = Stapler.getCurrentRequest2().getRequestURI();
+        return uri.matches(".*/stages/?$") && Jenkins.get().getPlugin("pipeline-graph-view") != null;
     }
 
     public String getRunUrl() {

--- a/src/main/java/io/jenkins/plugins/explain_error/ErrorExplainer.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ErrorExplainer.java
@@ -248,6 +248,12 @@ public class ErrorExplainer {
     ErrorExplanationAction explainErrorText(String errorText, String url, @NonNull Run<?, ?> run,
                                             UsageEvent.EntryPoint entryPoint)
             throws IOException, ExplanationException {
+        return explainErrorText(errorText, url, run, entryPoint, true);
+    }
+
+    ErrorExplanationAction explainErrorText(String errorText, String url, @NonNull Run<?, ?> run,
+                                            UsageEvent.EntryPoint entryPoint, boolean storeBuildAction)
+            throws IOException, ExplanationException {
         String jobInfo ="[" + run.getParent().getFullName() + " #" + run.getNumber() + "]";
         long startTimeNanos = System.nanoTime();
         int inputLogLineCount = countLines(errorText);
@@ -289,8 +295,10 @@ public class ErrorExplainer {
             LOGGER.fine("Explanation length: " + explanation.length());
             ErrorExplanationAction action = new ErrorExplanationAction(explanation, url, errorText,
                     provider.getProviderName(), provider.getModel(), inputLogLineCount);
-            run.addOrReplaceAction(action);
-            run.save();
+            if (storeBuildAction) {
+                run.addOrReplaceAction(action);
+                run.save();
+            }
             recordUsage(entryPoint, UsageEvent.Result.SUCCESS, provider, startTimeNanos, inputLogLineCount, false);
 
             return action;

--- a/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
@@ -322,6 +322,48 @@ public class PipelineLogExtractor {
         return extractFailedStepLog(true);
     }
 
+    public ExtractionResult extractNodeLog(String nodeId) throws IOException {
+        stats.reset();
+        String trimmedNodeId = nodeId != null ? nodeId.trim() : "";
+        setUrl(trimmedNodeId.isEmpty() ? "0" : trimmedNodeId);
+
+        if (trimmedNodeId.isEmpty() || !(this.run instanceof WorkflowRun workflowRun)) {
+            return emptyExtractionResult(trimmedNodeId);
+        }
+
+        FlowExecution execution = workflowRun.getExecution();
+        if (execution == null) {
+            return emptyExtractionResult(trimmedNodeId);
+        }
+
+        FlowNode requestedNode = execution.getNode(trimmedNodeId);
+        if (requestedNode == null) {
+            return emptyExtractionResult(trimmedNodeId);
+        }
+
+        FlowNode logNode = resolveNodeWithLog(requestedNode, execution);
+        if (logNode == null) {
+            return emptyExtractionResult(trimmedNodeId);
+        }
+
+        List<String> stepLog = readLimitedLog(logNode.getAction(LogAction.class).getLogText(), maxLines);
+        if (stepLog == null || stepLog.isEmpty()) {
+            return emptyExtractionResult(trimmedNodeId);
+        }
+
+        addHeaderLog(logNode, stepLog);
+        return new ExtractionResult(
+                stepLog,
+                url,
+                false,
+                true,
+                logNode.getId(),
+                false,
+                0,
+                0,
+                0);
+    }
+
     private ExtractionResult extractFailedStepLog(boolean resetStats) throws IOException {
         if (resetStats) {
             stats.reset();
@@ -444,6 +486,39 @@ public class PipelineLogExtractor {
      */
     FlowNode resolveOrigin(Throwable error, FlowExecution execution) {
         return ErrorAction.findOrigin(error, execution);
+    }
+
+    private FlowNode resolveNodeWithLog(FlowNode node, FlowExecution execution) {
+        if (node.getAction(LogAction.class) != null) {
+            return node;
+        }
+
+        ErrorAction errorAction = node.getError();
+        if (errorAction != null) {
+            FlowNode origin = resolveOrigin(errorAction.getError(), execution);
+            if (origin != null && origin.getAction(LogAction.class) != null) {
+                return origin;
+            }
+            FlowNode immediateParent = findImmediateParentWithLog(origin != null ? origin : node);
+            if (immediateParent != null) {
+                return immediateParent;
+            }
+        }
+
+        return findImmediateParentWithLog(node);
+    }
+
+    private ExtractionResult emptyExtractionResult(String nodeId) {
+        return new ExtractionResult(
+                List.of(),
+                url,
+                false,
+                false,
+                nodeId == null || nodeId.isBlank() ? null : nodeId,
+                false,
+                0,
+                0,
+                0);
     }
 
     private void setUrl(String node)

--- a/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
@@ -342,31 +342,130 @@ public class PipelineLogExtractor {
         }
 
         FlowNode logNode = resolveNodeWithLog(requestedNode, execution);
-        if (logNode == null) {
+        List<String> directStepLog = readNodeLog(logNode);
+        if (!directStepLog.isEmpty()) {
+            addHeaderLog(logNode, directStepLog);
+            return new ExtractionResult(
+                    directStepLog,
+                    url,
+                    false,
+                    true,
+                    logNode.getId(),
+                    false,
+                    0,
+                    0,
+                    0);
+        }
+
+        List<String> descendantStepLog = collectDescendantNodeLogs(
+                execution,
+                trimmedNodeId);
+        if (descendantStepLog.isEmpty()) {
             return emptyExtractionResult(trimmedNodeId);
         }
 
-        LogAction logAction = logNode.getAction(LogAction.class);
-        if (logAction == null) {
-            return emptyExtractionResult(trimmedNodeId);
-        }
-
-        List<String> stepLog = readLimitedLog(logAction.getLogText(), maxLines);
-        if (stepLog == null || stepLog.isEmpty()) {
-            return emptyExtractionResult(trimmedNodeId);
-        }
-
-        addHeaderLog(logNode, stepLog);
         return new ExtractionResult(
-                stepLog,
+                descendantStepLog,
                 url,
                 false,
                 true,
-                logNode.getId(),
+                trimmedNodeId,
                 false,
                 0,
                 0,
                 0);
+    }
+
+    private List<String> readNodeLog(final FlowNode node) {
+        if (node == null) {
+            return Collections.emptyList();
+        }
+
+        LogAction logAction = node.getAction(LogAction.class);
+        if (logAction == null) {
+            return Collections.emptyList();
+        }
+
+        List<String> stepLog = readLimitedLog(logAction.getLogText(), maxLines);
+        return stepLog == null ? Collections.emptyList() : stepLog;
+    }
+
+    private List<String> collectDescendantNodeLogs(
+            final FlowExecution execution,
+            final String selectedNodeId) {
+        List<FlowNode> failureNodes = new ArrayList<>();
+        List<FlowNode> logNodes = new ArrayList<>();
+        FlowGraphWalker walker = new FlowGraphWalker(execution);
+        for (FlowNode node : walker) {
+            if (selectedNodeId.equals(node.getId())
+                    || !hasLogAction(node)
+                    || !hasAncestor(node, selectedNodeId)) {
+                continue;
+            }
+
+            logNodes.add(node);
+            if (hasFailureSignal(node)) {
+                failureNodes.add(node);
+            }
+        }
+
+        List<FlowNode> selectedNodes = failureNodes.isEmpty()
+                ? logNodes
+                : failureNodes;
+        List<String> accumulated = new ArrayList<>();
+        for (FlowNode node : selectedNodes) {
+            int remainingLines = maxLines - accumulated.size();
+            if (remainingLines <= 0) {
+                break;
+            }
+
+            LogAction logAction = node.getAction(LogAction.class);
+            List<String> stepLog = readLimitedLog(
+                    logAction.getLogText(),
+                    remainingLines);
+            if (stepLog == null || stepLog.isEmpty()) {
+                continue;
+            }
+
+            addHeaderLog(node, stepLog);
+            accumulated.addAll(stepLog);
+        }
+        return accumulated;
+    }
+
+    private boolean hasLogAction(final FlowNode node) {
+        return node.getAction(LogAction.class) != null;
+    }
+
+    private boolean hasFailureSignal(final FlowNode node) {
+        if (node.getError() != null) {
+            return true;
+        }
+
+        WarningAction warningAction = node.getAction(WarningAction.class);
+        return warningAction != null
+                && warningAction.getResult() == Result.FAILURE;
+    }
+
+    private boolean hasAncestor(
+            final FlowNode node,
+            final String ancestorNodeId) {
+        Queue<FlowNode> queue = new LinkedList<>();
+        Set<String> visited = new HashSet<>();
+        queue.addAll(node.getParents());
+        while (!queue.isEmpty()) {
+            FlowNode current = queue.poll();
+            if (!visited.add(current.getId())) {
+                continue;
+            }
+
+            if (ancestorNodeId.equals(current.getId())) {
+                return true;
+            }
+
+            queue.addAll(current.getParents());
+        }
+        return false;
     }
 
     private ExtractionResult extractFailedStepLog(boolean resetStats) throws IOException {

--- a/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
@@ -420,6 +420,10 @@ public class PipelineLogExtractor {
             }
 
             LogAction logAction = node.getAction(LogAction.class);
+            if (logAction == null) {
+                continue;
+            }
+
             List<String> stepLog = readLimitedLog(
                     logAction.getLogText(),
                     remainingLines);

--- a/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
@@ -346,7 +346,12 @@ public class PipelineLogExtractor {
             return emptyExtractionResult(trimmedNodeId);
         }
 
-        List<String> stepLog = readLimitedLog(logNode.getAction(LogAction.class).getLogText(), maxLines);
+        LogAction logAction = logNode.getAction(LogAction.class);
+        if (logAction == null) {
+            return emptyExtractionResult(trimmedNodeId);
+        }
+
+        List<String> stepLog = readLimitedLog(logAction.getLogText(), maxLines);
         if (stepLog == null || stepLog.isEmpty()) {
             return emptyExtractionResult(trimmedNodeId);
         }

--- a/src/main/java/io/jenkins/plugins/explain_error/StepErrorExplanationAction.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/StepErrorExplanationAction.java
@@ -1,0 +1,120 @@
+package io.jenkins.plugins.explain_error;
+
+import hudson.model.Run;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import jenkins.model.RunAction2;
+
+/**
+ * Hidden build action storing AI explanations generated for individual Pipeline graph nodes.
+ */
+public class StepErrorExplanationAction implements RunAction2 {
+
+    private final Map<String, Entry> explanationsByNodeId = new LinkedHashMap<>();
+    private transient Run<?, ?> run;
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+    @Override
+    public void onAttached(Run<?, ?> r) {
+        this.run = r;
+    }
+
+    @Override
+    public void onLoad(Run<?, ?> r) {
+        this.run = r;
+    }
+
+    public Run<?, ?> getRun() {
+        return run;
+    }
+
+    public Entry getExplanation(String nodeId) {
+        if (nodeId == null) {
+            return null;
+        }
+        return explanationsByNodeId.get(nodeId);
+    }
+
+    public void putExplanation(String nodeId, ErrorExplanationAction action) {
+        explanationsByNodeId.put(nodeId, new Entry(
+                nodeId,
+                action.getExplanation(),
+                action.getUrlString(),
+                action.getProviderName(),
+                action.getProviderModel(),
+                action.getInputLogLineCount(),
+                action.getTimestamp()));
+    }
+
+    public boolean hasExplanation(String nodeId) {
+        Entry entry = getExplanation(nodeId);
+        return entry != null && entry.hasValidExplanation();
+    }
+
+    public static final class Entry {
+        private final String nodeId;
+        private final String explanation;
+        private final String urlString;
+        private final String providerName;
+        private final String providerModel;
+        private final int inputLogLineCount;
+        private final long timestamp;
+
+        Entry(String nodeId, String explanation, String urlString, String providerName,
+              String providerModel, int inputLogLineCount, long timestamp) {
+            this.nodeId = nodeId;
+            this.explanation = explanation;
+            this.urlString = urlString;
+            this.providerName = providerName;
+            this.providerModel = providerModel;
+            this.inputLogLineCount = Math.max(0, inputLogLineCount);
+            this.timestamp = timestamp;
+        }
+
+        public String getNodeId() {
+            return nodeId;
+        }
+
+        public String getExplanation() {
+            return explanation;
+        }
+
+        public String getUrlString() {
+            return urlString;
+        }
+
+        public String getProviderName() {
+            return providerName;
+        }
+
+        public String getProviderModel() {
+            return providerModel;
+        }
+
+        public int getInputLogLineCount() {
+            return inputLogLineCount;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+
+        public boolean hasValidExplanation() {
+            return explanation != null && !explanation.isBlank();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/explain_error/StepErrorExplanationAction.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/StepErrorExplanationAction.java
@@ -66,13 +66,17 @@ public class StepErrorExplanationAction implements RunAction2 {
     }
 
     public static final class Entry {
-        private final String nodeId;
-        private final String explanation;
-        private final String urlString;
-        private final String providerName;
-        private final String providerModel;
-        private final int inputLogLineCount;
-        private final long timestamp;
+        private String nodeId;
+        private String explanation;
+        private String urlString;
+        private String providerName;
+        private String providerModel;
+        private int inputLogLineCount;
+        private long timestamp;
+
+        /** No-arg constructor for XStream deserialization. */
+        private Entry() {
+        }
 
         Entry(String nodeId, String explanation, String urlString, String providerName,
               String providerModel, int inputLogLineCount, long timestamp) {

--- a/src/main/java/io/jenkins/plugins/explain_error/UsageEvent.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/UsageEvent.java
@@ -26,7 +26,8 @@ public record UsageEvent(
 
     public enum EntryPoint {
         PIPELINE_STEP("pipeline_step"),
-        CONSOLE_ACTION("console_action");
+        CONSOLE_ACTION("console_action"),
+        PIPELINE_GRAPH_NODE("pipeline_graph_node");
 
         private final String value;
 

--- a/src/main/resources/io/jenkins/plugins/explain_error/ConsolePageDecorator/footer.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/ConsolePageDecorator/footer.jelly
@@ -6,7 +6,12 @@
       <j:set var="existingExplanation" value="${it.existingExplanation}" />
       <j:set var="hasExplanation" value="${existingExplanation != null}" />
       <j:if test="${enabled or hasExplanation}">
-        <script src="${rootURL}/plugin/explain-error/js/explain-error-footer.js" type="text/javascript"/>
+        <j:if test="${it.consolePage}">
+          <script src="${rootURL}/plugin/explain-error/js/explain-error-footer.js" type="text/javascript"/>
+        </j:if>
+        <j:if test="${it.pipelineGraphViewPage}">
+          <script src="${rootURL}/plugin/explain-error/js/explain-error-graph.js" type="text/javascript"/>
+        </j:if>
         <j:set var="controls">
           <j:if test="${enabled}">
             <a href="#" tooltip="${%reexplain(it.providerName)}" class="jenkins-card__reveal eep-generate-new-button">

--- a/src/main/webapp/js/explain-error-graph.js
+++ b/src/main/webapp/js/explain-error-graph.js
@@ -71,12 +71,16 @@ function installGraphExplainButton() {
     return;
   }
 
+  // Do not show the button unless the selected node is actually a failure.
+  if (!isSelectedNodeFailed()) {
+    return;
+  }
+
   const overflowRoot = document.getElementById('console-pipeline-overflow-root');
   if (!overflowRoot) {
     setTimeout(installGraphExplainButton, 500);
     return;
   }
-  overflowRoot.style.display = 'contents';
 
   const button = document.createElement('button');
   button.type = 'button';
@@ -85,8 +89,9 @@ function installGraphExplainButton() {
   button.onclick = function () {
     sendNodeExplainRequest(false);
   };
-  overflowRoot.appendChild(button);
-  Behaviour.applySubtree(overflowRoot, true);
+  // Insert as a sibling before the overflow root so we do not disturb its layout.
+  overflowRoot.parentNode.insertBefore(button, overflowRoot);
+  Behaviour.applySubtree(overflowRoot.parentNode, true);
   updateGraphExplainButton();
 }
 
@@ -208,12 +213,15 @@ function updateGraphExplainButton() {
 /**
  * Detects whether the selected Pipeline tree item represents a failed step
  * by inspecting the DOM for failure status indicators.
+ * <p>
+ * Returns {@code false} when the active tree item is not yet present in the
+ * DOM so that the button is never shown for steps whose status is unknown.
  */
 function isSelectedNodeFailed() {
   const activeItem = document.querySelector('.pgv-tree-item--active');
   if (!activeItem) {
-    // No active item yet — keep the button visible (fail open).
-    return true;
+    // No active item yet — do not show the button.
+    return false;
   }
 
   // Look for SVG status icons with failure colors.

--- a/src/main/webapp/js/explain-error-graph.js
+++ b/src/main/webapp/js/explain-error-graph.js
@@ -195,7 +195,6 @@ function updateGraphExplainButton() {
 Behaviour.specify(".eep-generate-new-button", "ExplainErrorGraphView", 0, function(e) {
   e.onclick = function(event) {
     event.preventDefault();
-    clearGraphExplanationContent();
     sendNodeExplainRequest(true);
   };
 });
@@ -287,8 +286,3 @@ function hideGraphContainer() {
   container.classList.add('jenkins-hidden');
 }
 
-function clearGraphExplanationContent() {
-  const content = document.getElementById('explain-error-content');
-  content.classList.add('jenkins-hidden');
-  content.textContent = '';
-}

--- a/src/main/webapp/js/explain-error-graph.js
+++ b/src/main/webapp/js/explain-error-graph.js
@@ -105,18 +105,27 @@ function installHistoryListener() {
   const originalPushState = history.pushState;
   history.pushState = function () {
     const result = originalPushState.apply(this, arguments);
-    setTimeout(updateGraphExplainButton, 0);
+    setTimeout(function() {
+      installGraphExplainButton();
+      updateGraphExplainButton();
+    }, 0);
     return result;
   };
 
   const originalReplaceState = history.replaceState;
   history.replaceState = function () {
     const result = originalReplaceState.apply(this, arguments);
-    setTimeout(updateGraphExplainButton, 0);
+    setTimeout(function() {
+      installGraphExplainButton();
+      updateGraphExplainButton();
+    }, 0);
     return result;
   };
 
-  window.addEventListener('popstate', updateGraphExplainButton);
+  window.addEventListener('popstate', function() {
+    installGraphExplainButton();
+    updateGraphExplainButton();
+  });
 }
 
 function observeGraphViewChanges() {
@@ -136,6 +145,11 @@ function observeGraphViewChanges() {
   if (overflowRoot) {
     observer.observe(overflowRoot, { childList: true });
   }
+
+  // Install the button immediately in case the pipeline graph is already rendered.
+  // This handles the case where the user navigates to this page with ?selected-node
+  // from the pipeline overview and the DOM is already settled.
+  installGraphExplainButton();
 }
 
 function getSelectedNodeId() {

--- a/src/main/webapp/js/explain-error-graph.js
+++ b/src/main/webapp/js/explain-error-graph.js
@@ -1,9 +1,54 @@
 document.addEventListener('DOMContentLoaded', function () {
   installHistoryListener();
-  installGraphExplainButton();
+  checkGraphBuildStatusAndInstallButton();
   updateGraphExplainButton();
   observeGraphViewChanges();
 });
+
+function checkGraphBuildStatusAndInstallButton() {
+  checkGraphBuildStatus(function(buildingStatus) {
+    if (buildingStatus == 2) {
+      installGraphExplainButton();
+      updateGraphExplainButton();
+    } else if (buildingStatus == 1) {
+      setTimeout(checkGraphBuildStatusAndInstallButton, 5000);
+    } else {
+      const button = document.querySelector('.explain-error-graph-btn');
+      if (button) {
+        button.remove();
+      }
+    }
+  });
+}
+
+function checkGraphBuildStatus(callback) {
+  const container = document.getElementById('explain-error-container');
+  if (!container) {
+    callback(0);
+    return;
+  }
+
+  const basePath = container.dataset.runUrl;
+  const rootURL = document.head.getAttribute("data-rooturl");
+  const url = rootURL + '/' + basePath + 'console-explain-error/checkBuildStatus';
+  const headers = crumb.wrap({
+    "Content-Type": "application/x-www-form-urlencoded",
+  });
+
+  fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: ""
+  })
+  .then(response => response.json())
+  .then(data => {
+    callback(data.buildingStatus);
+  })
+  .catch(error => {
+    console.warn('Error checking build status:', error);
+    callback(0);
+  });
+}
 
 function installGraphExplainButton() {
   if (document.querySelector('.explain-error-graph-btn')) {
@@ -15,6 +60,7 @@ function installGraphExplainButton() {
     setTimeout(installGraphExplainButton, 500);
     return;
   }
+  overflowRoot.style.display = 'contents';
 
   const button = document.createElement('button');
   button.type = 'button';
@@ -25,6 +71,7 @@ function installGraphExplainButton() {
   };
   overflowRoot.appendChild(button);
   Behaviour.applySubtree(overflowRoot, true);
+  updateGraphExplainButton();
 }
 
 function installHistoryListener() {

--- a/src/main/webapp/js/explain-error-graph.js
+++ b/src/main/webapp/js/explain-error-graph.js
@@ -1,5 +1,8 @@
+let graphBuildStatus = null;
+
 document.addEventListener('DOMContentLoaded', function () {
   installHistoryListener();
+  installGraphExplainButton();
   checkGraphBuildStatusAndInstallButton();
   updateGraphExplainButton();
   observeGraphViewChanges();
@@ -7,15 +10,20 @@ document.addEventListener('DOMContentLoaded', function () {
 
 function checkGraphBuildStatusAndInstallButton() {
   checkGraphBuildStatus(function(buildingStatus) {
-    if (buildingStatus == 2) {
+    if (buildingStatus == null) {
       installGraphExplainButton();
       updateGraphExplainButton();
-    } else if (buildingStatus == 1) {
-      setTimeout(checkGraphBuildStatusAndInstallButton, 5000);
+      return;
+    }
+
+    graphBuildStatus = buildingStatus;
+    if (buildingStatus == 0) {
+      removeGraphExplainButton();
     } else {
-      const button = document.querySelector('.explain-error-graph-btn');
-      if (button) {
-        button.remove();
+      installGraphExplainButton();
+      updateGraphExplainButton();
+      if (buildingStatus == 1) {
+        setTimeout(checkGraphBuildStatusAndInstallButton, 5000);
       }
     }
   });
@@ -24,16 +32,19 @@ function checkGraphBuildStatusAndInstallButton() {
 function checkGraphBuildStatus(callback) {
   const container = document.getElementById('explain-error-container');
   if (!container) {
-    callback(0);
+    callback(null);
     return;
   }
 
   const basePath = container.dataset.runUrl;
   const rootURL = document.head.getAttribute("data-rooturl");
   const url = rootURL + '/' + basePath + 'console-explain-error/checkBuildStatus';
-  const headers = crumb.wrap({
+  let headers = {
     "Content-Type": "application/x-www-form-urlencoded",
-  });
+  };
+  if (window.crumb && typeof window.crumb.wrap === 'function') {
+    headers = window.crumb.wrap(headers);
+  }
 
   fetch(url, {
     method: "POST",
@@ -46,11 +57,15 @@ function checkGraphBuildStatus(callback) {
   })
   .catch(error => {
     console.warn('Error checking build status:', error);
-    callback(0);
+    callback(null);
   });
 }
 
 function installGraphExplainButton() {
+  if (graphBuildStatus == 0) {
+    return;
+  }
+
   if (document.querySelector('.explain-error-graph-btn')) {
     return;
   }
@@ -72,6 +87,13 @@ function installGraphExplainButton() {
   overflowRoot.appendChild(button);
   Behaviour.applySubtree(overflowRoot, true);
   updateGraphExplainButton();
+}
+
+function removeGraphExplainButton() {
+  const button = document.querySelector('.explain-error-graph-btn');
+  if (button) {
+    button.remove();
+  }
 }
 
 function installHistoryListener() {
@@ -104,8 +126,16 @@ function observeGraphViewChanges() {
     return;
   }
 
-  const observer = new MutationObserver(updateGraphExplainButton);
+  const observer = new MutationObserver(function() {
+    installGraphExplainButton();
+    updateGraphExplainButton();
+  });
   observer.observe(root, { childList: true, subtree: true });
+
+  const overflowRoot = document.getElementById('console-pipeline-overflow-root');
+  if (overflowRoot) {
+    observer.observe(overflowRoot, { childList: true });
+  }
 }
 
 function getSelectedNodeId() {
@@ -123,8 +153,11 @@ function updateGraphExplainButton() {
   const nodeId = getSelectedNodeId();
   const container = document.getElementById('explain-error-container');
   const enabled = container && container.dataset.pluginEnabled === 'true';
-  button.disabled = !enabled || !nodeId;
-  button.setAttribute('tooltip', nodeId ? 'Explain Pipeline node ' + nodeId : 'Select a Pipeline step first');
+  const building = graphBuildStatus == 1;
+  button.disabled = !enabled || !nodeId || building;
+  button.setAttribute('tooltip', building
+      ? 'Build is still running'
+      : (nodeId ? 'Explain Pipeline node ' + nodeId : 'Select a Pipeline step first'));
 }
 
 Behaviour.specify(".eep-generate-new-button", "ExplainErrorGraphView", 0, function(e) {

--- a/src/main/webapp/js/explain-error-graph.js
+++ b/src/main/webapp/js/explain-error-graph.js
@@ -1,0 +1,182 @@
+document.addEventListener('DOMContentLoaded', function () {
+  installHistoryListener();
+  installGraphExplainButton();
+  updateGraphExplainButton();
+  observeGraphViewChanges();
+});
+
+function installGraphExplainButton() {
+  if (document.querySelector('.explain-error-graph-btn')) {
+    return;
+  }
+
+  const overflowRoot = document.getElementById('console-pipeline-overflow-root');
+  if (!overflowRoot) {
+    setTimeout(installGraphExplainButton, 500);
+    return;
+  }
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'jenkins-button explain-error-graph-btn';
+  button.textContent = 'Explain selected step';
+  button.onclick = function () {
+    sendNodeExplainRequest(false);
+  };
+  overflowRoot.appendChild(button);
+  Behaviour.applySubtree(overflowRoot, true);
+}
+
+function installHistoryListener() {
+  if (window.explainErrorGraphHistoryInstalled) {
+    return;
+  }
+  window.explainErrorGraphHistoryInstalled = true;
+
+  const originalPushState = history.pushState;
+  history.pushState = function () {
+    const result = originalPushState.apply(this, arguments);
+    setTimeout(updateGraphExplainButton, 0);
+    return result;
+  };
+
+  const originalReplaceState = history.replaceState;
+  history.replaceState = function () {
+    const result = originalReplaceState.apply(this, arguments);
+    setTimeout(updateGraphExplainButton, 0);
+    return result;
+  };
+
+  window.addEventListener('popstate', updateGraphExplainButton);
+}
+
+function observeGraphViewChanges() {
+  const root = document.getElementById('console-pipeline-root');
+  if (!root) {
+    setTimeout(observeGraphViewChanges, 500);
+    return;
+  }
+
+  const observer = new MutationObserver(updateGraphExplainButton);
+  observer.observe(root, { childList: true, subtree: true });
+}
+
+function getSelectedNodeId() {
+  const params = new URLSearchParams(window.location.search);
+  const nodeId = params.get('selected-node');
+  return nodeId ? nodeId.trim() : '';
+}
+
+function updateGraphExplainButton() {
+  const button = document.querySelector('.explain-error-graph-btn');
+  if (!button) {
+    return;
+  }
+
+  const nodeId = getSelectedNodeId();
+  const container = document.getElementById('explain-error-container');
+  const enabled = container && container.dataset.pluginEnabled === 'true';
+  button.disabled = !enabled || !nodeId;
+  button.setAttribute('tooltip', nodeId ? 'Explain Pipeline node ' + nodeId : 'Select a Pipeline step first');
+}
+
+Behaviour.specify(".eep-generate-new-button", "ExplainErrorGraphView", 0, function(e) {
+  e.onclick = function(event) {
+    event.preventDefault();
+    clearGraphExplanationContent();
+    sendNodeExplainRequest(true);
+  };
+});
+
+Behaviour.specify(".eep-close-button", "ExplainErrorGraphView", 0, function(e) {
+  e.onclick = function(event) {
+    event.preventDefault();
+    hideGraphContainer();
+  };
+});
+
+function sendNodeExplainRequest(forceNew = false) {
+  const nodeId = getSelectedNodeId();
+  if (!nodeId) {
+    notificationBar.show('Select a Pipeline step first', notificationBar.WARNING);
+    return;
+  }
+
+  const container = document.getElementById('explain-error-container');
+  const basePath = container.dataset.runUrl;
+  const rootURL = document.head.getAttribute("data-rooturl");
+  const url = rootURL + '/' + basePath + 'console-explain-error/explainNodeError';
+  const headers = crumb.wrap({
+    "Content-Type": "application/x-www-form-urlencoded",
+  });
+  const body = new URLSearchParams();
+  body.set('nodeId', nodeId);
+  if (forceNew) {
+    body.set('forceNew', 'true');
+  }
+
+  showGraphSpinner();
+
+  fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: body.toString()
+  })
+  .then(response => {
+    if (!response.ok) {
+      notificationBar.show('Explain failed', notificationBar.ERROR);
+    }
+    return response.json();
+  })
+  .then(json => {
+    if (json.status == "success") {
+      showGraphErrorExplanation(json.message, json.providerName, json.url);
+    } else {
+      if (json.status == "warning") {
+        notificationBar.show(json.message, notificationBar.WARNING);
+      } else {
+        notificationBar.show(json.message, notificationBar.ERROR);
+      }
+      hideGraphContainer();
+    }
+  })
+  .catch(error => {
+    notificationBar.show(`Error: ${error.message}`, notificationBar.ERROR);
+    hideGraphContainer();
+  });
+}
+
+function showGraphErrorExplanation(message, providerName, url) {
+  const container = document.getElementById('explain-error-container');
+  const spinner = document.getElementById('explain-error-spinner');
+  const content = document.getElementById('explain-error-content');
+  const urlString = document.getElementById('explain-error-url');
+  const cardTitle = container.querySelector('.jenkins-card__title');
+  if (cardTitle && cardTitle.firstChild) {
+    cardTitle.firstChild.textContent = `AI Step Explanation (${providerName})`;
+  }
+  container.classList.remove('jenkins-hidden');
+  spinner.classList.add('jenkins-hidden');
+  content.textContent = message;
+  content.classList.remove('jenkins-hidden');
+  urlString.classList.remove('jenkins-hidden');
+  urlString.href = url;
+}
+
+function showGraphSpinner() {
+  const container = document.getElementById('explain-error-container');
+  const spinner = document.getElementById('explain-error-spinner');
+  container.classList.remove('jenkins-hidden');
+  spinner.classList.remove('jenkins-hidden');
+}
+
+function hideGraphContainer() {
+  const container = document.getElementById('explain-error-container');
+  container.classList.add('jenkins-hidden');
+}
+
+function clearGraphExplanationContent() {
+  const content = document.getElementById('explain-error-content');
+  content.classList.add('jenkins-hidden');
+  content.textContent = '';
+}

--- a/src/main/webapp/js/explain-error-graph.js
+++ b/src/main/webapp/js/explain-error-graph.js
@@ -155,7 +155,25 @@ function observeGraphViewChanges() {
 function getSelectedNodeId() {
   const params = new URLSearchParams(window.location.search);
   const nodeId = params.get('selected-node');
-  return nodeId ? nodeId.trim() : '';
+  if (nodeId) {
+    return nodeId.trim();
+  }
+  // Fallback: detect the selected node from the DOM when the URL does not
+  // contain ?selected-node=. The pipeline-graph-view auto-selects the worst
+  // node (e.g. failed) on initial page load via React internal state without
+  // calling history.replaceState, so the URL is not updated.
+  const activeItem = document.querySelector('.pgv-tree-item--active');
+  if (activeItem && activeItem.href) {
+    const q = activeItem.href.indexOf('?');
+    if (q !== -1) {
+      const domParams = new URLSearchParams(activeItem.href.substring(q));
+      const domNodeId = domParams.get('selected-node');
+      if (domNodeId) {
+        return domNodeId.trim();
+      }
+    }
+  }
+  return '';
 }
 
 function updateGraphExplainButton() {

--- a/src/main/webapp/js/explain-error-graph.js
+++ b/src/main/webapp/js/explain-error-graph.js
@@ -1,4 +1,5 @@
 let graphBuildStatus = null;
+let lastCheckedNodeId = null;
 
 document.addEventListener('DOMContentLoaded', function () {
   installHistoryListener();
@@ -177,19 +178,93 @@ function getSelectedNodeId() {
 }
 
 function updateGraphExplainButton() {
-  const button = document.querySelector('.explain-error-graph-btn');
-  if (!button) {
-    return;
-  }
-
   const nodeId = getSelectedNodeId();
   const container = document.getElementById('explain-error-container');
   const enabled = container && container.dataset.pluginEnabled === 'true';
   const building = graphBuildStatus == 1;
-  button.disabled = !enabled || !nodeId || building;
-  button.setAttribute('tooltip', building
-      ? 'Build is still running'
-      : (nodeId ? 'Explain Pipeline node ' + nodeId : 'Select a Pipeline step first'));
+
+  const button = document.querySelector('.explain-error-graph-btn');
+  if (button) {
+    button.disabled = !enabled || !nodeId || building;
+    button.setAttribute('tooltip', building
+        ? 'Build is still running'
+        : (nodeId ? 'Explain Pipeline node ' + nodeId : 'Select a Pipeline step first'));
+  }
+
+  // When a node is selected, check whether it is a failure step (via DOM status
+  // indicators) and whether there is already a cached explanation.
+  // Skip if we already checked this node.
+  if (nodeId && nodeId !== lastCheckedNodeId) {
+    lastCheckedNodeId = nodeId;
+    if (isSelectedNodeFailed()) {
+      installGraphExplainButton();
+      tryShowCachedExplanation(nodeId);
+    } else {
+      removeGraphExplainButton();
+    }
+  }
+}
+
+/**
+ * Detects whether the selected Pipeline tree item represents a failed step
+ * by inspecting the DOM for failure status indicators.
+ */
+function isSelectedNodeFailed() {
+  const activeItem = document.querySelector('.pgv-tree-item--active');
+  if (!activeItem) {
+    // No active item yet — keep the button visible (fail open).
+    return true;
+  }
+
+  // Look for SVG status icons with failure colors.
+  // Jenkins pipeline-graph-view uses red (#c4000a or similar) for failures,
+  // blue/green for success.  We check the fill attribute on SVGs inside the
+  // tree item.
+  const svgs = activeItem.querySelectorAll('svg');
+  for (const svg of svgs) {
+    const fill = (svg.getAttribute('fill') || '').toLowerCase();
+    // Common Jenkins failure reds.
+    if (fill === '#c4000a' || fill === '#d32f2f' || fill === 'red' || fill === '#ff0000') {
+      return true;
+    }
+  }
+
+  // Fallback: check for well-known failure-related CSS classes.
+  if (activeItem.querySelector('[class*="--failed"], [class*="--FAILURE"], ' +
+      '[class*="--error"], .icon-red, .icon-red-anime')) {
+    return true;
+  }
+
+  // No failure indicator found — assume a green / success step.
+  return false;
+}
+
+function tryShowCachedExplanation(nodeId) {
+  const container = document.getElementById('explain-error-container');
+  const basePath = container.dataset.runUrl;
+  const rootURL = document.head.getAttribute("data-rooturl");
+  const url = rootURL + '/' + basePath + 'console-explain-error/getNodeExplanation';
+  let headers = {
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+  if (window.crumb && typeof window.crumb.wrap === 'function') {
+    headers = window.crumb.wrap(headers);
+  }
+
+  fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: "nodeId=" + encodeURIComponent(nodeId)
+  })
+  .then(response => response.json())
+  .then(data => {
+    if (data.status === "success") {
+      showGraphErrorExplanation(data.message, data.providerName, data.url);
+    }
+  })
+  .catch(error => {
+    console.warn('Error fetching cached explanation:', error);
+  });
 }
 
 Behaviour.specify(".eep-generate-new-button", "ExplainErrorGraphView", 0, function(e) {
@@ -285,4 +360,3 @@ function hideGraphContainer() {
   const container = document.getElementById('explain-error-container');
   container.classList.add('jenkins-hidden');
 }
-

--- a/src/test/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorActionTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorActionTest.java
@@ -298,6 +298,61 @@ class ConsoleExplainErrorActionTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void testGetNodeExplanationReturnsCached() throws Exception {
+        WorkflowJob workflowJob = rule.createProject(WorkflowJob.class, "graph-get-node-explain");
+        workflowJob.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                + "    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {\n"
+                + "        sh 'echo \"GET_NODE_CACHE_A\" && exit 1'\n"
+                + "    }\n"
+                + "}",
+                true));
+        WorkflowRun workflowRun = rule.assertBuildStatus(Result.FAILURE, workflowJob.scheduleBuild2(0));
+        String nodeId = findNodeIdWithLog(workflowRun, "GET_NODE_CACHE_A");
+
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            // First, no cache should exist.
+            URL url = new URL(rule.jenkins.getRootUrl() + workflowRun.getUrl()
+                    + "console-explain-error/getNodeExplanation");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            request.setRequestParameters(java.util.List.of(
+                    new org.htmlunit.util.NameValuePair("nodeId", nodeId)
+            ));
+            Page page = client.getPage(request);
+            JSONObject json = JSONObject.fromObject(page.getWebResponse().getContentAsString());
+            assertEquals("no_cache", json.getString("status"));
+
+            // Generate an explanation.
+            URL explainUrl = new URL(rule.jenkins.getRootUrl() + workflowRun.getUrl()
+                    + "console-explain-error/explainNodeError");
+            WebRequest explainRequest = new WebRequest(explainUrl, HttpMethod.POST);
+            explainRequest.setRequestParameters(java.util.List.of(
+                    new org.htmlunit.util.NameValuePair("nodeId", nodeId)
+            ));
+            client.getPage(explainRequest);
+
+            // Now the cache should return the explanation.
+            page = client.getPage(request);
+            json = JSONObject.fromObject(page.getWebResponse().getContentAsString());
+            assertEquals("success", json.getString("status"));
+            assertTrue(json.getString("message").contains("Summary:"));
+        }
+    }
+
+    @Test
+    void testGetNodeExplanationMissingNodeId() throws IOException {
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl() + build.getUrl()
+                    + "console-explain-error/getNodeExplanation");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            Page page = client.getPage(request);
+            JSONObject json = JSONObject.fromObject(page.getWebResponse().getContentAsString());
+            assertEquals("warning", json.getString("status"));
+        }
+    }
+
+    @Test
     void testCheckBuildStatus() throws Exception {
         try (JenkinsRule.WebClient client = rule.createWebClient()) {
             URL url = new URL(rule.jenkins.getRootUrl() + build.getUrl() + "console-explain-error/checkBuildStatus");

--- a/src/test/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorActionTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorActionTest.java
@@ -8,7 +8,6 @@ import hudson.model.Result;
 import io.jenkins.plugins.explain_error.provider.TestProvider;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.lang.reflect.Method;
 import java.net.URL;
 import net.sf.json.JSONObject;
 import org.htmlunit.HttpMethod;
@@ -58,62 +57,6 @@ class ConsoleExplainErrorActionTest {
         assertNull(action.getIconFileName()); // Should be null for AJAX functionality
         assertNull(action.getDisplayName()); // Should be null for AJAX functionality
         assertEquals("console-explain-error", action.getUrlName());
-    }
-
-    @Test
-    void testCreateCachedResponse() throws Exception {
-        // Use reflection to access the private method
-        Method method = ConsoleExplainErrorAction.class.getDeclaredMethod("createCachedResponse", String.class);
-        method.setAccessible(true);
-
-        String originalExplanation = "This is the original AI explanation.";
-        String cachedResponse = (String) method.invoke(action, originalExplanation);
-
-        assertNotNull(cachedResponse);
-        assertTrue(cachedResponse.contains(originalExplanation));
-        assertTrue(cachedResponse.contains("previously generated explanation"));
-        assertTrue(cachedResponse.contains("Generate New"));
-    }
-
-    @Test
-    void testCreateCachedResponseWithNullInput() throws Exception {
-        String cachedResponse = action.createCachedResponse(null);
-
-        assertNotNull(cachedResponse);
-        assertTrue(cachedResponse.contains("null"));
-        assertTrue(cachedResponse.contains("previously generated explanation"));
-    }
-
-    @Test
-    void testCreateCachedResponseWithEmptyInput() throws Exception {
-        String cachedResponse = action.createCachedResponse("");
-
-        assertNotNull(cachedResponse);
-        assertTrue(cachedResponse.contains("previously generated explanation"));
-    }
-
-    @Test
-    void testCreateCachedResponseWithLongExplanation() throws Exception {
-        StringBuilder longExplanation = new StringBuilder();
-        for (int i = 0; i < 100; i++) {
-            longExplanation.append("This is line ").append(i).append(" of a very long explanation.\n");
-        }
-
-        String cachedResponse = action.createCachedResponse(longExplanation.toString());
-
-        assertNotNull(cachedResponse);
-        assertTrue(cachedResponse.contains(longExplanation.toString()));
-        assertTrue(cachedResponse.contains("previously generated explanation"));
-    }
-
-    @Test
-    void testCreateCachedResponseWithSpecialCharacters() throws Exception {
-        String specialExplanation = "Error with special chars: <>&\"'\nUnicode: ñáéíóú 中文 العربية";
-        String cachedResponse = action.createCachedResponse(specialExplanation);
-
-        assertNotNull(cachedResponse);
-        assertTrue(cachedResponse.contains(specialExplanation));
-        assertTrue(cachedResponse.contains("previously generated explanation"));
     }
 
     @Test
@@ -230,7 +173,6 @@ class ConsoleExplainErrorActionTest {
             page = client.getPage(request);
             responseJson = JSONObject.fromObject(page.getWebResponse().getContentAsString());
             assertEquals("success", responseJson.getString("status"));
-            assertTrue(responseJson.getString("message").contains("previously generated explanation"));
             assertEquals(1, provider.getCallCount(), "Second call should use the node cache");
 
             request.setRequestParameters(java.util.List.of(

--- a/src/test/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorActionTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorActionTest.java
@@ -4,12 +4,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Result;
 import io.jenkins.plugins.explain_error.provider.TestProvider;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.concurrent.ExecutionException;
 import net.sf.json.JSONObject;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
@@ -28,6 +28,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.UnstableBuilder;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
@@ -246,6 +247,43 @@ class ConsoleExplainErrorActionTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void testExplainNodeErrorUsesSelectedParentNodeDescendantLog() throws Exception {
+        WorkflowJob workflowJob = rule.createProject(WorkflowJob.class, "graph-parent-node-explain");
+        workflowJob.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                + "    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {\n"
+                + "        sh 'echo \"GRAPH_PARENT_ENDPOINT_A\" && exit 1'\n"
+                + "    }\n"
+                + "    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {\n"
+                + "        sh 'echo \"GRAPH_PARENT_ENDPOINT_B\" && exit 1'\n"
+                + "    }\n"
+                + "}",
+                true));
+        WorkflowRun workflowRun = rule.assertBuildStatus(Result.FAILURE, workflowJob.scheduleBuild2(0));
+        String parentNodeId = findNearestParentNodeIdWithoutLog(workflowRun, "GRAPH_PARENT_ENDPOINT_B");
+
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl() + workflowRun.getUrl()
+                    + "console-explain-error/explainNodeError");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            request.setRequestParameters(java.util.List.of(
+                    new org.htmlunit.util.NameValuePair("nodeId", parentNodeId)
+            ));
+            Page page = client.getPage(request);
+            JSONObject responseJson = JSONObject.fromObject(page.getWebResponse().getContentAsString());
+            assertEquals("success", responseJson.getString("status"));
+
+            StepErrorExplanationAction stepAction = workflowRun.getAction(StepErrorExplanationAction.class);
+            assertNotNull(stepAction);
+            assertTrue(stepAction.hasExplanation(parentNodeId));
+            assertEquals(1, provider.getCallCount());
+            assertTrue(provider.getLastErrorLogs().contains("GRAPH_PARENT_ENDPOINT_B"));
+            assertFalse(provider.getLastErrorLogs().contains("GRAPH_PARENT_ENDPOINT_A"));
+        }
+    }
+
+    @Test
     void testExplainNodeErrorRequiresNodeId() throws IOException {
         try (JenkinsRule.WebClient client = rule.createWebClient()) {
             URL url = new URL(rule.jenkins.getRootUrl() + build.getUrl()
@@ -260,7 +298,7 @@ class ConsoleExplainErrorActionTest {
     }
 
     @Test
-    void testCheckBuildStatus() throws IOException, ExecutionException, InterruptedException {
+    void testCheckBuildStatus() throws Exception {
         try (JenkinsRule.WebClient client = rule.createWebClient()) {
             URL url = new URL(rule.jenkins.getRootUrl() + build.getUrl() + "console-explain-error/checkBuildStatus");
             WebRequest request = new WebRequest(url, HttpMethod.POST);
@@ -289,6 +327,31 @@ class ConsoleExplainErrorActionTest {
             content = page.getWebResponse().getContentAsString();
             responseJson = JSONObject.fromObject(content);
             assertEquals(2, responseJson.getInt("buildingStatus"));
+
+            project.getBuildersList().clear();
+            project.getBuildersList().add(new UnstableBuilder());
+            build = project.scheduleBuild2(0).get();
+            url = new URL(rule.jenkins.getRootUrl() + build.getUrl() + "console-explain-error/checkBuildStatus");
+            request = new WebRequest(url, HttpMethod.POST);
+            page = client.getPage(request);
+            content = page.getWebResponse().getContentAsString();
+            responseJson = JSONObject.fromObject(content);
+            assertEquals(0, responseJson.getInt("buildingStatus"));
+
+            WorkflowJob abortedJob = rule.createProject(WorkflowJob.class, "aborted-status");
+            abortedJob.setDefinition(new CpsFlowDefinition(
+                    "node {\n"
+                    + "    currentBuild.result = 'ABORTED'\n"
+                    + "    echo 'aborted status marker'\n"
+                    + "}",
+                    true));
+            WorkflowRun abortedRun = rule.assertBuildStatus(Result.ABORTED, abortedJob.scheduleBuild2(0));
+            url = new URL(rule.jenkins.getRootUrl() + abortedRun.getUrl() + "console-explain-error/checkBuildStatus");
+            request = new WebRequest(url, HttpMethod.POST);
+            page = client.getPage(request);
+            content = page.getWebResponse().getContentAsString();
+            responseJson = JSONObject.fromObject(content);
+            assertEquals(0, responseJson.getInt("buildingStatus"));
         }
     }
 
@@ -308,5 +371,18 @@ class ConsoleExplainErrorActionTest {
             }
         }
         throw new AssertionError("No FlowNode log contained marker: " + marker);
+    }
+
+    private String findNearestParentNodeIdWithoutLog(WorkflowRun run, String marker) throws Exception {
+        FlowExecution execution = run.getExecution();
+        assertNotNull(execution, "Pipeline execution should be available");
+        FlowNode logNode = execution.getNode(findNodeIdWithLog(run, marker));
+        assertNotNull(logNode, "Log node should be available");
+        for (FlowNode parent : logNode.getParents()) {
+            if (parent.getAction(LogAction.class) == null) {
+                return parent.getId();
+            }
+        }
+        throw new AssertionError("No parent FlowNode without log found for marker: " + marker);
     }
 }

--- a/src/test/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorActionTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ConsoleExplainErrorActionTest.java
@@ -6,6 +6,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import io.jenkins.plugins.explain_error.provider.TestProvider;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.concurrent.ExecutionException;
@@ -15,6 +16,15 @@ import org.htmlunit.Page;
 import org.htmlunit.WebRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.jenkinsci.plugins.workflow.actions.LogAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
@@ -178,6 +188,78 @@ class ConsoleExplainErrorActionTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void testExplainNodeErrorCachesByNodeAndDoesNotCreateBuildExplanation() throws Exception {
+        WorkflowJob workflowJob = rule.createProject(WorkflowJob.class, "graph-node-explain");
+        workflowJob.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                + "    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {\n"
+                + "        sh 'echo \"GRAPH_NODE_ENDPOINT_A\" && exit 1'\n"
+                + "    }\n"
+                + "    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {\n"
+                + "        sh 'echo \"GRAPH_NODE_ENDPOINT_B\" && exit 1'\n"
+                + "    }\n"
+                + "}",
+                true));
+        WorkflowRun workflowRun = rule.assertBuildStatus(hudson.model.Result.FAILURE,
+                workflowJob.scheduleBuild2(0));
+        String nodeId = findNodeIdWithLog(workflowRun, "GRAPH_NODE_ENDPOINT_B");
+
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl() + workflowRun.getUrl()
+                    + "console-explain-error/explainNodeError");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            request.setRequestParameters(java.util.List.of(
+                    new org.htmlunit.util.NameValuePair("nodeId", nodeId)
+            ));
+            Page page = client.getPage(request);
+            JSONObject responseJson = JSONObject.fromObject(page.getWebResponse().getContentAsString());
+            assertEquals("success", responseJson.getString("status"));
+
+            StepErrorExplanationAction stepAction = workflowRun.getAction(StepErrorExplanationAction.class);
+            assertNotNull(stepAction);
+            assertTrue(stepAction.hasExplanation(nodeId));
+            assertNull(workflowRun.getAction(ErrorExplanationAction.class),
+                    "Step explanation must not overwrite the build-level explanation action");
+            assertEquals(1, provider.getCallCount());
+            assertTrue(provider.getLastErrorLogs().contains("GRAPH_NODE_ENDPOINT_B"));
+            assertFalse(provider.getLastErrorLogs().contains("GRAPH_NODE_ENDPOINT_A"));
+
+            provider.setAnswerMessage("Second graph call");
+            page = client.getPage(request);
+            responseJson = JSONObject.fromObject(page.getWebResponse().getContentAsString());
+            assertEquals("success", responseJson.getString("status"));
+            assertTrue(responseJson.getString("message").contains("previously generated explanation"));
+            assertEquals(1, provider.getCallCount(), "Second call should use the node cache");
+
+            request.setRequestParameters(java.util.List.of(
+                    new org.htmlunit.util.NameValuePair("nodeId", nodeId),
+                    new org.htmlunit.util.NameValuePair("forceNew", "true")
+            ));
+            client.getPage(request);
+            assertEquals(2, provider.getCallCount(), "forceNew should bypass the node cache");
+            assertEquals("Summary: Second graph call\n",
+                    workflowRun.getAction(StepErrorExplanationAction.class)
+                            .getExplanation(nodeId)
+                            .getExplanation());
+        }
+    }
+
+    @Test
+    void testExplainNodeErrorRequiresNodeId() throws IOException {
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl() + build.getUrl()
+                    + "console-explain-error/explainNodeError");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            Page page = client.getPage(request);
+            JSONObject responseJson = JSONObject.fromObject(page.getWebResponse().getContentAsString());
+            assertEquals("warning", responseJson.getString("status"));
+            assertTrue(responseJson.getString("message").contains("No Pipeline node"));
+            assertEquals(0, provider.getCallCount());
+        }
+    }
+
+    @Test
     void testCheckBuildStatus() throws IOException, ExecutionException, InterruptedException {
         try (JenkinsRule.WebClient client = rule.createWebClient()) {
             URL url = new URL(rule.jenkins.getRootUrl() + build.getUrl() + "console-explain-error/checkBuildStatus");
@@ -208,5 +290,23 @@ class ConsoleExplainErrorActionTest {
             responseJson = JSONObject.fromObject(content);
             assertEquals(2, responseJson.getInt("buildingStatus"));
         }
+    }
+
+    private String findNodeIdWithLog(WorkflowRun run, String marker) throws Exception {
+        FlowExecution execution = run.getExecution();
+        assertNotNull(execution, "Pipeline execution should be available");
+        FlowGraphWalker walker = new FlowGraphWalker(execution);
+        for (FlowNode node : walker) {
+            LogAction logAction = node.getAction(LogAction.class);
+            if (logAction == null) {
+                continue;
+            }
+            StringWriter writer = new StringWriter();
+            logAction.getLogText().writeLogTo(0, writer);
+            if (writer.toString().contains(marker)) {
+                return node.getId();
+            }
+        }
+        throw new AssertionError("No FlowNode log contained marker: " + marker);
     }
 }

--- a/src/test/java/io/jenkins/plugins/explain_error/ConsolePageDecoratorUriTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ConsolePageDecoratorUriTest.java
@@ -1,0 +1,19 @@
+package io.jenkins.plugins.explain_error;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ConsolePageDecoratorUriTest {
+
+    @Test
+    void testPipelineGraphViewUriSupportsCurrentAndLegacyUrls() {
+        assertTrue(ConsolePageDecorator.isPipelineGraphViewUri("/job/test/1/stages"));
+        assertTrue(ConsolePageDecorator.isPipelineGraphViewUri("/job/test/1/stages/"));
+        assertTrue(ConsolePageDecorator.isPipelineGraphViewUri("/job/test/1/pipeline-overview"));
+        assertTrue(ConsolePageDecorator.isPipelineGraphViewUri("/job/test/1/pipeline-overview/"));
+        assertFalse(ConsolePageDecorator.isPipelineGraphViewUri("/job/test/1/console"));
+        assertFalse(ConsolePageDecorator.isPipelineGraphViewUri("/job/test/1/stages/log"));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/explain_error/MetricsUsageRecorderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/MetricsUsageRecorderTest.java
@@ -42,6 +42,15 @@ class MetricsUsageRecorderTest {
     }
 
     @Test
+    void requestCounterIncrementedForPipelineGraphNode() {
+        recorder.record(event(UsageEvent.EntryPoint.PIPELINE_GRAPH_NODE, UsageEvent.Result.SUCCESS,
+                "OpenAI", "gpt-4o", 100L, 12));
+
+        assertEquals(1, registry.counter("explain_error.requests.pipeline_graph_node.success").getCount());
+        assertEquals(1, registry.counter("explain_error.provider_calls.openai.gpt-4o.success").getCount());
+    }
+
+    @Test
     void requestCounterIncrementedForDisabled() {
         recorder.record(event(UsageEvent.EntryPoint.PIPELINE_STEP, UsageEvent.Result.DISABLED,
                 "OpenAI", "gpt-4o", 0L, 0));

--- a/src/test/java/io/jenkins/plugins/explain_error/PipelineLogExtractorTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/PipelineLogExtractorTest.java
@@ -171,6 +171,38 @@ class PipelineLogExtractorTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void extractNodeLog_selectedParentNodeReturnsFailedDescendantLog(JenkinsRule jenkins) throws Exception {
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-selected-parent-node-log");
+        job.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                + "    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {\n"
+                + "        sh 'echo \"SELECTED_PARENT_A\" && exit 1'\n"
+                + "    }\n"
+                + "    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {\n"
+                + "        sh 'echo \"SELECTED_PARENT_B\" && exit 1'\n"
+                + "    }\n"
+                + "}",
+                true));
+
+        WorkflowRun run = jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
+        String parentNodeId = findNearestParentNodeIdWithoutLog(run, "SELECTED_PARENT_B");
+
+        PipelineLogExtractor extractor = new PipelineLogExtractor(run, 200);
+        PipelineLogExtractor.ExtractionResult result = extractor.extractNodeLog(parentNodeId);
+        String log = String.join("\n", result.logLines());
+
+        assertTrue(result.foundFailingNode(), "Selected parent extraction should report descendant node logs");
+        assertEquals(parentNodeId, result.primaryNodeId(), "Selected parent should remain the primary node");
+        assertTrue(log.contains("SELECTED_PARENT_B"),
+                "Selected parent's descendant failure log should be included.\nActual log:\n" + log);
+        assertFalse(log.contains("SELECTED_PARENT_A"),
+                "Unselected sibling parent log must not be included.\nActual log:\n" + log);
+        assertTrue(result.url().contains("selected-node=" + parentNodeId),
+                "URL should deep-link to the selected parent node");
+    }
+
+    @Test
     void extractNodeLog_missingNodeReturnsEmptyResult(JenkinsRule jenkins) throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-missing-node-log");
         job.setDefinition(new CpsFlowDefinition("node { echo 'ok' }", true));
@@ -978,6 +1010,19 @@ class PipelineLogExtractorTest {
             }
         }
         throw new AssertionError("No FlowNode log contained marker: " + marker);
+    }
+
+    private String findNearestParentNodeIdWithoutLog(WorkflowRun run, String marker) throws Exception {
+        FlowExecution execution = run.getExecution();
+        assertNotNull(execution, "Pipeline execution should be available");
+        FlowNode logNode = execution.getNode(findNodeIdWithLog(run, marker));
+        assertNotNull(logNode, "Log node should be available");
+        for (FlowNode parent : logNode.getParents()) {
+            if (parent.getAction(LogAction.class) == null) {
+                return parent.getId();
+            }
+        }
+        throw new AssertionError("No parent FlowNode without log found for marker: " + marker);
     }
 
     private Authentication configureReadAccess(JenkinsRule jenkins, String username) {

--- a/src/test/java/io/jenkins/plugins/explain_error/PipelineLogExtractorTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/PipelineLogExtractorTest.java
@@ -24,6 +24,7 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import io.jenkins.plugins.explain_error.provider.TestProvider;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -34,6 +35,7 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -136,6 +138,62 @@ class PipelineLogExtractorTest {
         String log = String.join("\n", lines);
         assertTrue(log.contains("STANDARD_ERROR_OUTPUT"),
                 "Strategy 1 should extract the sh step log containing the error output.\nActual log:\n" + log);
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void extractNodeLog_returnsOnlySelectedNodeLog(JenkinsRule jenkins) throws Exception {
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-selected-node-log");
+        job.setDefinition(new CpsFlowDefinition(
+                "node {\n"
+                + "    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {\n"
+                + "        sh 'echo \"SELECTED_NODE_A\" && exit 1'\n"
+                + "    }\n"
+                + "    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {\n"
+                + "        sh 'echo \"SELECTED_NODE_B\" && exit 1'\n"
+                + "    }\n"
+                + "}",
+                true));
+
+        WorkflowRun run = jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
+        String nodeId = findNodeIdWithLog(run, "SELECTED_NODE_B");
+
+        PipelineLogExtractor extractor = new PipelineLogExtractor(run, 200);
+        PipelineLogExtractor.ExtractionResult result = extractor.extractNodeLog(nodeId);
+        String log = String.join("\n", result.logLines());
+
+        assertTrue(result.foundFailingNode(), "Selected node extraction should report a node log");
+        assertEquals(nodeId, result.primaryNodeId(), "Selected node should be the primary node");
+        assertTrue(log.contains("SELECTED_NODE_B"), "Selected node log should be included.\nActual log:\n" + log);
+        assertFalse(log.contains("SELECTED_NODE_A"),
+                "Unselected sibling step log must not be included.\nActual log:\n" + log);
+        assertTrue(result.url().contains("selected-node=" + nodeId), "URL should deep-link to the selected node");
+    }
+
+    @Test
+    void extractNodeLog_missingNodeReturnsEmptyResult(JenkinsRule jenkins) throws Exception {
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-missing-node-log");
+        job.setDefinition(new CpsFlowDefinition("node { echo 'ok' }", true));
+        WorkflowRun run = jenkins.buildAndAssertSuccess(job);
+
+        PipelineLogExtractor extractor = new PipelineLogExtractor(run, 200);
+        PipelineLogExtractor.ExtractionResult result = extractor.extractNodeLog("missing-node");
+
+        assertTrue(result.logLines().isEmpty(), "Missing node should not fall back to full console log");
+        assertFalse(result.foundFailingNode(), "Missing node should not report a found node");
+        assertEquals("missing-node", result.primaryNodeId());
+    }
+
+    @Test
+    void extractNodeLog_nonPipelineRunReturnsEmptyResult(JenkinsRule jenkins) throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject("test-node-log-freestyle");
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+
+        PipelineLogExtractor extractor = new PipelineLogExtractor(build, 200);
+        PipelineLogExtractor.ExtractionResult result = extractor.extractNodeLog("1");
+
+        assertTrue(result.logLines().isEmpty(), "Non-Pipeline node extraction should not use console fallback");
+        assertFalse(result.foundFailingNode(), "Non-Pipeline run should not report a Pipeline node");
     }
 
     /**
@@ -902,6 +960,24 @@ class PipelineLogExtractorTest {
 
         assertFalse(log.contains("### Downstream Job:"),
                 "UpstreamCause fallback should skip unreadable downstream jobs entirely.\nActual log:\n" + log);
+    }
+
+    private String findNodeIdWithLog(WorkflowRun run, String marker) throws Exception {
+        FlowExecution execution = run.getExecution();
+        assertNotNull(execution, "Pipeline execution should be available");
+        FlowGraphWalker walker = new FlowGraphWalker(execution);
+        for (FlowNode node : walker) {
+            LogAction logAction = node.getAction(LogAction.class);
+            if (logAction == null) {
+                continue;
+            }
+            StringWriter writer = new StringWriter();
+            logAction.getLogText().writeLogTo(0, writer);
+            if (writer.toString().contains(marker)) {
+                return node.getId();
+            }
+        }
+        throw new AssertionError("No FlowNode log contained marker: " + marker);
     }
 
     private Authentication configureReadAccess(JenkinsRule jenkins, String username) {


### PR DESCRIPTION
## Summary

Adds "Explain selected step" button and AI explanation display to the Pipeline Graph View, enabling per-node error explanations.

## Changes

### New Files
- **`StepErrorExplanationAction.java`** - Hidden `RunAction2` that caches per-node AI explanations in a `LinkedHashMap<String, Entry>`
- **`explain-error-graph.js`** - JavaScript that injects "Explain selected step" button into the pipeline graph view app bar, detects selected node from URL params, and sends AJAX requests to the new `explainNodeError` endpoint
- **`ConsolePageDecoratorUriTest.java`** - URI matching tests for pipeline graph view pages

### Modified Files
- **`ConsoleExplainErrorAction.java`** - New `doExplainNodeError()` endpoint that extracts a specific node's log and explains it; refactored `doCheckBuildStatus`; added `getOrCreateStepAction()` and `parseMaxLines()` helpers
- **`ConsolePageDecorator.java`** - Extended to recognize pipeline graph view pages (`/stages` and `/pipeline-overview`) and check that the `pipeline-graph-view` plugin is installed
- **`ErrorExplainer.java`** - New `explainErrorText()` overload with `storeBuildAction` parameter to avoid overwriting console-level explanations when explaining nodes
- **`PipelineLogExtractor.java`** - New `extractNodeLog()` method with node-log resolution (direct log, error origin, parent with log, descendant collection)
- **`UsageEvent.java`** - New `PIPELINE_GRAPH_NODE` entry point
- **`footer.jelly`** - Conditionally loads `explain-error-graph.js` vs `explain-error-footer.js` based on page type

### Test Updates
- `ConsoleExplainErrorActionTest` - Tests for node explanation caching, parent node fallback, missing nodeId validation, and build status (including UNSTABLE/ABORTED)
- `PipelineLogExtractorTest` - Tests for selected node extraction, parent node fallback, missing node, and non-pipeline runs
- `MetricsUsageRecorderTest` - Coverage for `PIPELINE_GRAPH_NODE` entry point

## Architecture

1. `ConsolePageDecorator` detects pipeline graph view pages by URL match AND verifies `pipeline-graph-view` plugin is installed
2. The button is injected into `#console-pipeline-overflow-root` in the app bar
3. Node ID is read from `?selected-node=` URL parameter
4. Explanation output appears in the shared `explain-error-container` footer card
5. Explanations are cached per-node in `StepErrorExplanationAction` to avoid redundant API calls

## Testing

- Manual: Button only appears on FAILURE builds with pipeline-graph-view installed
- Manual: Button disabled when no node selected or build running
- Manual: Node explanations cached independently from console explanations
- Unit tests cover all key scenarios
