### PR TITLE
feat: add Pipeline Graph View integration for AI Explain

### DIFF
--- a/src/main/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorAction.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorAction.java
@@ -1,0 +1,333 @@
+package io.jenkins.plugins.explain_error;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.model.Result;
+import hudson.model.Run;
+import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import jenkins.model.RunAction2;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.workflow.actions.ErrorAction;
+import org.jenkinsci.plugins.workflow.actions.WarningAction;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+/**
+ * Action for the Pipeline Graph View integration.
+ * Provides AJAX endpoints to check node status and explain errors
+ * for a specific selected node in the Pipeline Graph View.
+ */
+public class GraphViewExplainErrorAction implements RunAction2 {
+
+    private static final Logger LOGGER = Logger.getLogger(GraphViewExplainErrorAction.class.getName());
+
+    private transient Run<?, ?> run;
+    private String urlString;
+
+    public GraphViewExplainErrorAction(Run<?, ?> run) {
+        this.run = run;
+    }
+
+    @Override
+    public void onAttached(Run<?, ?> r) {
+        this.run = r;
+    }
+
+    @Override
+    public void onLoad(Run<?, ?> r) {
+        this.run = r;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return "graph-explain-error";
+    }
+
+    /**
+     * AJAX endpoint to check build status.
+     * Returns JSON with buildingStatus: 0 = SUCCESS, 1 = RUNNING, 2 = FINISHED and FAILURE.
+     */
+    @RequirePOST
+    public void doCheckBuildStatus(StaplerRequest2 req, StaplerResponse2 rsp) {
+        try {
+            run.checkPermission(hudson.model.Item.READ);
+
+            int buildingStatus = run.isBuilding() ? 1 : 0;
+
+            if (buildingStatus == 0) {
+                Result result = run.getResult();
+                if (result == Result.SUCCESS) {
+                    buildingStatus = 0;
+                } else {
+                    buildingStatus = 2;
+                }
+            }
+
+            rsp.setContentType("application/json");
+            rsp.setCharacterEncoding("UTF-8");
+            PrintWriter writer = rsp.getWriter();
+            writer.write("{\"buildingStatus\": " + buildingStatus + "}");
+            writer.flush();
+        } catch (Exception e) {
+            LOGGER.warning("Error checking build status: " + e.getMessage());
+            rsp.setStatus(500);
+        }
+    }
+
+    /**
+     * AJAX endpoint to check whether a specific flow node is a failed node.
+     * Returns {@code isFailed: true} if the node (or any of its descendants)
+     * has an {@link ErrorAction} or a {@link WarningAction} with result
+     * {@link Result#FAILURE}.
+     */
+    @RequirePOST
+    public void doCheckNodeStatus(StaplerRequest2 req, StaplerResponse2 rsp) {
+        try {
+            run.checkPermission(hudson.model.Item.READ);
+
+            String nodeId = req.getParameter("nodeId");
+            boolean isFailed = isFailedNode(nodeId);
+
+            rsp.setContentType("application/json");
+            rsp.setCharacterEncoding("UTF-8");
+            PrintWriter writer = rsp.getWriter();
+
+            JSONObject json = new JSONObject();
+            json.put("isFailed", isFailed);
+            writer.write(json.toString());
+            writer.flush();
+        } catch (Exception e) {
+            LOGGER.warning("Error checking node status: " + e.getMessage());
+            rsp.setStatus(500);
+        }
+    }
+
+    /**
+     * AJAX endpoint to explain an error for a specific selected node.
+     * First checks if an existing {@link ErrorExplanationAction} is already
+     * present (cache hit). Otherwise extracts logs from the specified node
+     * and calls the AI provider.
+     */
+    @RequirePOST
+    public void doExplainNodeError(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException {
+        long startTimeNanos = System.nanoTime();
+        try {
+            run.checkPermission(hudson.model.Item.READ);
+
+            GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+            if (!config.isEnableExplanation()) {
+                BaseAIProvider provider = config.getAiProvider();
+                recordUsage(UsageEvent.Result.DISABLED,
+                        provider != null ? provider.getProviderName() : null,
+                        provider != null ? provider.getModel() : null,
+                        startTimeNanos, 0);
+                writeJsonResponse(rsp, "warning", "Unknown",
+                        "AI error explanation is disabled in global configuration.");
+                return;
+            }
+
+            String nodeId = req.getParameter("nodeId");
+            if (nodeId == null || nodeId.isBlank()) {
+                writeJsonResponse(rsp, "error", "Unknown", "No node selected.");
+                return;
+            }
+
+            // Check if user wants to force a new explanation
+            boolean forceNew = "true".equals(req.getParameter("forceNew"));
+
+            // Check if an explanation already exists
+            ErrorExplanationAction existingAction = run.getAction(ErrorExplanationAction.class);
+            if (!forceNew && existingAction != null && existingAction.hasValidExplanation()) {
+                recordUsage(UsageEvent.Result.CACHE_HIT, existingAction.getProviderName(),
+                        existingAction.getProviderModel(), startTimeNanos,
+                        existingAction.getInputLogLineCount());
+                writeJsonResponse(rsp, "success", existingAction.getProviderName(),
+                        createCachedResponse(existingAction.getExplanation()));
+                return;
+            }
+
+            // Extract logs from the selected node
+            PipelineLogExtractor logExtractor = new PipelineLogExtractor(run, 200,
+                    Jenkins.getAuthentication2(), false, null);
+            List<String> logLines = logExtractor.extractNodeLog(nodeId);
+            this.urlString = logExtractor.getUrl();
+
+            if (logLines.isEmpty()) {
+                writeJsonResponse(rsp, "error", "Unknown",
+                        "No log output found for the selected node.");
+                return;
+            }
+
+            String errorText = String.join("\n", logLines);
+
+            ErrorExplainer explainer = new ErrorExplainer();
+            try {
+                ErrorExplanationAction action = explainer.explainErrorText(errorText, urlString, run);
+                writeJsonResponse(rsp, "success", action.getProviderName(), action.getExplanation());
+            } catch (ExplanationException ee) {
+                writeJsonResponse(rsp, ee.getLevel(), explainer.getProviderName(), ee.getMessage());
+            }
+        } catch (Exception e) {
+            LOGGER.severe("Error explaining node error: " + e.getMessage());
+            writeJsonResponse(rsp, "error", "Unknown", "Error: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Determines whether a flow node (or any of its descendants) represents
+     * a failure.
+     * <p>
+     * A node is considered failed if:
+     * <ul>
+     *   <li>It has an {@link ErrorAction} directly, or</li>
+     *   <li>It has a {@link WarningAction} with {@link Result#FAILURE}, or</li>
+     *   <li>Any of its descendants (via BFS) has an {@link ErrorAction}.</li>
+     * </ul>
+     *
+     * @param nodeId the flow node ID to check
+     * @return {@code true} if the node or its descendants contain a failure
+     */
+    @VisibleForTesting
+    boolean isFailedNode(String nodeId) {
+        if (nodeId == null || nodeId.isBlank()) {
+            return false;
+        }
+        if (!(run instanceof WorkflowRun)) {
+            return false;
+        }
+        FlowExecution execution = ((WorkflowRun) run).getExecution();
+        if (execution == null) {
+            return false;
+        }
+
+        FlowGraphWalker walker = new FlowGraphWalker(execution);
+        FlowNode targetNode = null;
+        for (FlowNode node : walker) {
+            if (node.getId().equals(nodeId)) {
+                targetNode = node;
+                break;
+            }
+        }
+        if (targetNode == null) {
+            return false;
+        }
+
+        // Check the node itself
+        if (targetNode.getError() != null) {
+            return true;
+        }
+        WarningAction warn = targetNode.getAction(WarningAction.class);
+        if (warn != null && warn.getResult() == Result.FAILURE) {
+            return true;
+        }
+
+        // Walk the full graph and check if any node with ErrorAction
+        // has targetNode in its ancestor chain
+        FlowGraphWalker walker2 = new FlowGraphWalker(execution);
+        for (FlowNode node : walker2) {
+            if (node.getError() == null) {
+                continue;
+            }
+            if (node.getId().equals(nodeId)) {
+                return true;
+            }
+            if (isDescendantOf(node, targetNode)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether {@code node} is a descendant of {@code ancestor} by
+     * walking the node's parent chain.
+     */
+    private boolean isDescendantOf(FlowNode node, FlowNode ancestor) {
+        Set<String> visited = new HashSet<>();
+        Queue<FlowNode> queue = new LinkedList<>();
+        queue.add(node);
+
+        while (!queue.isEmpty()) {
+            FlowNode current = queue.poll();
+            if (!visited.add(current.getId())) {
+                continue;
+            }
+            if (current.getId().equals(ancestor.getId())) {
+                return true;
+            }
+            // Check parents — if we reach the ancestor, node is a descendant
+            queue.addAll(current.getParents());
+            // Stop searching if we've gone past the ancestor's position
+            // (approximation: stop if we've searched too many nodes)
+            if (visited.size() > 10_000) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private void writeJsonResponse(StaplerResponse2 rsp, String status, String providerName,
+                                   String message) throws IOException {
+        rsp.setContentType("application/json");
+        rsp.setCharacterEncoding("UTF-8");
+        PrintWriter writer = rsp.getWriter();
+
+        JSONObject json = new JSONObject();
+        json.put("status", status);
+        json.put("providerName", providerName);
+        json.put("message", message);
+        json.put("url", urlString);
+        writer.write(json.toString());
+        writer.flush();
+    }
+
+    /**
+     * Create a response indicating this is a cached result.
+     */
+    @VisibleForTesting
+    String createCachedResponse(String explanation) {
+        return explanation
+                + "\n\n[Note: This is a previously generated explanation. "
+                + "Use the 'Generate New' option to create a new one.]";
+    }
+
+    public Run<?, ?> getRun() {
+        return run;
+    }
+
+    private void recordUsage(UsageEvent.Result result, String providerName, String model,
+                             long startTimeNanos, int inputLogLineCount) {
+        UsageRecorders.get().record(new UsageEvent(
+                System.currentTimeMillis(),
+                UsageEvent.EntryPoint.CONSOLE_ACTION,
+                result,
+                providerName,
+                model,
+                Math.max(0L, (System.nanoTime() - startTimeNanos) / 1_000_000L),
+                inputLogLineCount,
+                false));
+    }
+}

--- a/src/main/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorAction.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorAction.java
@@ -6,11 +6,7 @@ import hudson.model.Run;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Queue;
-import java.util.Set;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.model.RunAction2;
@@ -161,6 +157,7 @@ public class GraphViewExplainErrorAction implements RunAction2 {
             // Check if an explanation already exists
             ErrorExplanationAction existingAction = run.getAction(ErrorExplanationAction.class);
             if (!forceNew && existingAction != null && existingAction.hasValidExplanation()) {
+                this.urlString = existingAction.getUrlString();
                 recordUsage(UsageEvent.Result.CACHE_HIT, existingAction.getProviderName(),
                         existingAction.getProviderModel(), startTimeNanos,
                         existingAction.getInputLogLineCount());
@@ -197,18 +194,23 @@ public class GraphViewExplainErrorAction implements RunAction2 {
     }
 
     /**
-     * Determines whether a flow node (or any of its descendants) represents
+     * Determines whether a flow node (or any node it encloses) represents
      * a failure.
      * <p>
      * A node is considered failed if:
      * <ul>
      *   <li>It has an {@link ErrorAction} directly, or</li>
      *   <li>It has a {@link WarningAction} with {@link Result#FAILURE}, or</li>
-     *   <li>Any of its descendants (via BFS) has an {@link ErrorAction}.</li>
+     *   <li>It is a block node (e.g. a stage) and a node enclosed by it fails
+     *       by either of the above criteria.</li>
      * </ul>
+     * Containment is determined via {@link FlowNode#getEnclosingBlocks()}
+     * rather than the parent chain: parents link to execution-order
+     * predecessors, so following them would wrongly mark every node that ran
+     * before the failure as failed.
      *
      * @param nodeId the flow node ID to check
-     * @return {@code true} if the node or its descendants contain a failure
+     * @return {@code true} if the node or a node it encloses failed
      */
     @VisibleForTesting
     boolean isFailedNode(String nodeId) {
@@ -223,67 +225,45 @@ public class GraphViewExplainErrorAction implements RunAction2 {
             return false;
         }
 
-        FlowGraphWalker walker = new FlowGraphWalker(execution);
-        FlowNode targetNode = null;
-        for (FlowNode node : walker) {
-            if (node.getId().equals(nodeId)) {
-                targetNode = node;
-                break;
-            }
-        }
+        FlowNode targetNode = findNode(execution, nodeId);
         if (targetNode == null) {
             return false;
         }
 
-        // Check the node itself
-        if (targetNode.getError() != null) {
-            return true;
-        }
-        WarningAction warn = targetNode.getAction(WarningAction.class);
-        if (warn != null && warn.getResult() == Result.FAILURE) {
+        if (isFailure(targetNode)) {
             return true;
         }
 
-        // Walk the full graph and check if any node with ErrorAction
-        // has targetNode in its ancestor chain
-        FlowGraphWalker walker2 = new FlowGraphWalker(execution);
-        for (FlowNode node : walker2) {
-            if (node.getError() == null) {
-                continue;
-            }
-            if (node.getId().equals(nodeId)) {
-                return true;
-            }
-            if (isDescendantOf(node, targetNode)) {
+        FlowGraphWalker walker = new FlowGraphWalker(execution);
+        for (FlowNode node : walker) {
+            if (isFailure(node) && isEnclosedBy(node, nodeId)) {
                 return true;
             }
         }
         return false;
     }
 
-    /**
-     * Checks whether {@code node} is a descendant of {@code ancestor} by
-     * walking the node's parent chain.
-     */
-    private boolean isDescendantOf(FlowNode node, FlowNode ancestor) {
-        Set<String> visited = new HashSet<>();
-        Queue<FlowNode> queue = new LinkedList<>();
-        queue.add(node);
+    private static FlowNode findNode(FlowExecution execution, String nodeId) {
+        for (FlowNode node : new FlowGraphWalker(execution)) {
+            if (node.getId().equals(nodeId)) {
+                return node;
+            }
+        }
+        return null;
+    }
 
-        while (!queue.isEmpty()) {
-            FlowNode current = queue.poll();
-            if (!visited.add(current.getId())) {
-                continue;
-            }
-            if (current.getId().equals(ancestor.getId())) {
+    private static boolean isFailure(FlowNode node) {
+        if (node.getError() != null) {
+            return true;
+        }
+        WarningAction warn = node.getAction(WarningAction.class);
+        return warn != null && warn.getResult() == Result.FAILURE;
+    }
+
+    private static boolean isEnclosedBy(FlowNode node, String blockId) {
+        for (FlowNode enclosing : node.getEnclosingBlocks()) {
+            if (enclosing.getId().equals(blockId)) {
                 return true;
-            }
-            // Check parents — if we reach the ancestor, node is a descendant
-            queue.addAll(current.getParents());
-            // Stop searching if we've gone past the ancestor's position
-            // (approximation: stop if we've searched too many nodes)
-            if (visited.size() > 10_000) {
-                return false;
             }
         }
         return false;

--- a/src/main/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorActionFactory.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorActionFactory.java
@@ -1,0 +1,46 @@
+package io.jenkins.plugins.explain_error;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Run;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import jenkins.model.TransientActionFactory;
+
+/**
+ * TransientActionFactory to dynamically inject
+ * {@link GraphViewExplainErrorAction} into all runs when the
+ * {@code pipeline-graph-view} plugin is installed.
+ */
+@Extension
+public class GraphViewExplainErrorActionFactory extends TransientActionFactory<Run<?, ?>> {
+
+    private static final Logger LOGGER = Logger.getLogger(
+            GraphViewExplainErrorActionFactory.class.getName());
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<Run<?, ?>> type() {
+        return (Class<Run<?, ?>>) (Class<?>) Run.class;
+    }
+
+    @NonNull
+    @Override
+    public Collection<? extends Action> createFor(@NonNull Run<?, ?> run) {
+        try {
+            // Only inject when pipeline-graph-view plugin is installed
+            if (Jenkins.get().getPlugin("pipeline-graph-view") == null) {
+                return Collections.emptyList();
+            }
+            GraphViewExplainErrorAction action = new GraphViewExplainErrorAction(run);
+            return Collections.singletonList(action);
+        } catch (Exception e) {
+            LOGGER.severe("Failed to create GraphViewExplainErrorAction for run: "
+                    + run.getFullDisplayName() + ". Error: " + e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/explain_error/PipelineGraphViewDecorator.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/PipelineGraphViewDecorator.java
@@ -6,6 +6,7 @@ import hudson.model.Run;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Page decorator to add "Explain Error" functionality to Pipeline Graph View pages.
@@ -53,8 +54,14 @@ public class PipelineGraphViewDecorator extends PageDecorator {
         if (Jenkins.get().getPlugin("pipeline-graph-view") == null) {
             return false;
         }
-        String uri = Stapler.getCurrentRequest2().getRequestURI();
-        return uri.matches(".*/stages(\\?.*)?$");
+        StaplerRequest2 req = Stapler.getCurrentRequest2();
+        if (req == null) {
+            return false;
+        }
+        String uri = req.getRequestURI();
+        // Pipeline Graph View renders as a Tab at e.g. /job/xxx/1/stages/
+        // The trailing slash is part of the URL; also handle query params
+        return uri.matches(".*/stages(/.*)?(\\?.*)?$");
     }
 
     public String getRunUrl() {

--- a/src/main/java/io/jenkins/plugins/explain_error/PipelineGraphViewDecorator.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/PipelineGraphViewDecorator.java
@@ -1,0 +1,77 @@
+package io.jenkins.plugins.explain_error;
+
+import hudson.Extension;
+import hudson.model.PageDecorator;
+import hudson.model.Run;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.Ancestor;
+import org.kohsuke.stapler.Stapler;
+
+/**
+ * Page decorator to add "Explain Error" functionality to Pipeline Graph View pages.
+ * Injects JavaScript that monitors node selection and provides an
+ * "Explain Error" button for failed nodes.
+ */
+@Extension
+public class PipelineGraphViewDecorator extends PageDecorator {
+
+    public PipelineGraphViewDecorator() {
+        super();
+    }
+
+    /**
+     * Returns {@code true} when the explain-error plugin is configured
+     * and enabled.
+     */
+    public boolean isExplainErrorEnabled() {
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+
+        if (!config.isEnableExplanation()) {
+            return false;
+        }
+
+        if (config.getAiProvider() == null) {
+            return false;
+        }
+
+        return !config.getAiProvider().isNotValid(null);
+    }
+
+    public String getProviderName() {
+        if (GlobalConfigurationImpl.get().getAiProvider() == null) {
+            return null;
+        }
+        return GlobalConfigurationImpl.get().getAiProvider().getProviderName();
+    }
+
+    /**
+     * Checks whether the current request is on a Pipeline Graph View page.
+     * Only active when the {@code pipeline-graph-view} plugin is installed
+     * and the URL matches the graph view pattern.
+     */
+    public boolean isPluginActive() {
+        if (Jenkins.get().getPlugin("pipeline-graph-view") == null) {
+            return false;
+        }
+        String uri = Stapler.getCurrentRequest2().getRequestURI();
+        return uri.matches(".*/stages(\\?.*)?$");
+    }
+
+    public String getRunUrl() {
+        Ancestor ancestor = Stapler.getCurrentRequest2().findAncestor(Run.class);
+        if (ancestor != null && ancestor.getObject() instanceof Run<?, ?> run) {
+            return run.getUrl();
+        } else {
+            return null;
+        }
+    }
+
+    public ErrorExplanationAction getExistingExplanation() {
+        Ancestor ancestor = Stapler.getCurrentRequest2().findAncestor(Run.class);
+        if (ancestor != null && ancestor.getObject() instanceof Run<?, ?> run) {
+            return run.getAction(ErrorExplanationAction.class);
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
@@ -359,10 +359,14 @@ public class PipelineLogExtractor {
         }
 
         FlowNode logNode = target;
-        if (target.getAction(LogAction.class) == null) {
+        if (target.getAction(LogAction.class) == null
+                || !hasLogContent(target.getAction(LogAction.class))) {
             // A block node's failure output lives in the nodes it encloses;
             // a step node's missing log may live in its immediate parent
             // (catchError + sh(returnStatus:true) + error() pattern).
+            // Also enter this branch when the target has a LogAction but its
+            // content is empty (e.g. the error() step creates a node with a
+            // LogAction that carries no output).
             logNode = target instanceof BlockStartNode
                     ? findFailedEnclosedNodeWithLog(execution, nodeId)
                     : findImmediateParentWithLog(target);
@@ -401,7 +405,7 @@ public class PipelineLogExtractor {
             if (!isEnclosedBy(node, blockId) || !isFailedFlowNode(node)) {
                 continue;
             }
-            if (node.getAction(LogAction.class) != null) {
+            if (node.getAction(LogAction.class) != null && hasLogContent(node.getAction(LogAction.class))) {
                 return node;
             }
             FlowNode parent = findImmediateParentWithLog(node);
@@ -410,6 +414,15 @@ public class PipelineLogExtractor {
             }
         }
         return null;
+    }
+
+    private static boolean hasLogContent(LogAction logAction) {
+        try {
+            StringWriter sw = new StringWriter();
+            return logAction.getLogText().writeLogTo(0, sw) > 0;
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     private static boolean isFailedFlowNode(FlowNode node) {

--- a/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
@@ -6,6 +6,7 @@ import hudson.model.Item;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
@@ -323,9 +324,14 @@ public class PipelineLogExtractor {
      * Used by the Pipeline Graph View integration to extract logs for the
      * node that the user selected.
      * <p>
-     * Supports the {@code catchError + sh(returnStatus:true) + error()} pattern
-     * by falling back to the immediate parent when the target node has no
-     * {@link LogAction}.
+     * When the target node itself has no {@link LogAction}:
+     * <ul>
+     *   <li>For a block node (e.g. a stage selected in the graph view), the
+     *       log of the failing node <em>enclosed</em> by the block is used —
+     *       the failure lives inside the block, not before it.</li>
+     *   <li>For a step node, the immediate parent is checked to support the
+     *       {@code catchError + sh(returnStatus:true) + error()} pattern.</li>
+     * </ul>
      *
      * @param nodeId the flow node ID to extract logs from
      * @return the log lines for the specified node, or an empty list if the
@@ -341,31 +347,86 @@ public class PipelineLogExtractor {
             return Collections.emptyList();
         }
 
-        FlowGraphWalker walker = new FlowGraphWalker(execution);
-        for (FlowNode node : walker) {
-            if (!node.getId().equals(nodeId)) {
+        FlowNode target = null;
+        for (FlowNode node : new FlowGraphWalker(execution)) {
+            if (node.getId().equals(nodeId)) {
+                target = node;
+                break;
+            }
+        }
+        if (target == null) {
+            return Collections.emptyList();
+        }
+
+        FlowNode logNode = target;
+        if (target.getAction(LogAction.class) == null) {
+            // A block node's failure output lives in the nodes it encloses;
+            // a step node's missing log may live in its immediate parent
+            // (catchError + sh(returnStatus:true) + error() pattern).
+            logNode = target instanceof BlockStartNode
+                    ? findFailedEnclosedNodeWithLog(execution, nodeId)
+                    : findImmediateParentWithLog(target);
+            if (logNode == null) {
+                return Collections.emptyList();
+            }
+        }
+
+        LogAction logAction = logNode.getAction(LogAction.class);
+        if (logAction == null) {
+            return Collections.emptyList();
+        }
+        List<String> stepLog = readLimitedLog(logAction.getLogText(), maxLines);
+        if (stepLog.isEmpty()) {
+            return Collections.emptyList();
+        }
+        addHeaderLog(logNode, stepLog);
+        setUrl(nodeId);
+        return stepLog;
+    }
+
+    /**
+     * Finds a failed node (one with an {@link ErrorAction}, or a
+     * {@link WarningAction} with result {@link Result#FAILURE}) that is
+     * enclosed by the given block node and carries a {@link LogAction}.
+     * When the failed node itself has no log (e.g. an {@code error()} step),
+     * its immediate parent is used if it has a log and lives inside the same
+     * block.
+     *
+     * @param execution the flow execution to search
+     * @param blockId   the ID of the enclosing block node (e.g. a stage)
+     * @return the enclosed failed node with a log, or {@code null} if none
+     */
+    private FlowNode findFailedEnclosedNodeWithLog(FlowExecution execution, String blockId) {
+        for (FlowNode node : new FlowGraphWalker(execution)) {
+            if (!isEnclosedBy(node, blockId) || !isFailedFlowNode(node)) {
                 continue;
             }
-            LogAction logAction = node.getAction(LogAction.class);
-            // catchError + sh(returnStatus:true) + error() fallback
-            if (logAction == null) {
-                FlowNode immediateParent = findImmediateParentWithLog(node);
-                if (immediateParent != null) {
-                    logAction = immediateParent.getAction(LogAction.class);
-                }
+            if (node.getAction(LogAction.class) != null) {
+                return node;
             }
-            if (logAction == null) {
-                return Collections.emptyList();
+            FlowNode parent = findImmediateParentWithLog(node);
+            if (parent != null && isEnclosedBy(parent, blockId)) {
+                return parent;
             }
-            List<String> stepLog = readLimitedLog(logAction.getLogText(), maxLines);
-            if (stepLog.isEmpty()) {
-                return Collections.emptyList();
-            }
-            addHeaderLog(node, stepLog);
-            setUrl(nodeId);
-            return stepLog;
         }
-        return Collections.emptyList();
+        return null;
+    }
+
+    private static boolean isFailedFlowNode(FlowNode node) {
+        if (node.getError() != null) {
+            return true;
+        }
+        WarningAction warn = node.getAction(WarningAction.class);
+        return warn != null && warn.getResult() == Result.FAILURE;
+    }
+
+    private static boolean isEnclosedBy(FlowNode node, String blockId) {
+        for (FlowNode enclosing : node.getEnclosingBlocks()) {
+            if (enclosing.getId().equals(blockId)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public ExtractionResult extractFailedStepLog() throws IOException {

--- a/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
@@ -318,6 +318,56 @@ public class PipelineLogExtractor {
         return extractFailedStepLog().logLines();
     }
 
+    /**
+     * Extracts log lines from a specific flow node identified by its node ID.
+     * Used by the Pipeline Graph View integration to extract logs for the
+     * node that the user selected.
+     * <p>
+     * Supports the {@code catchError + sh(returnStatus:true) + error()} pattern
+     * by falling back to the immediate parent when the target node has no
+     * {@link LogAction}.
+     *
+     * @param nodeId the flow node ID to extract logs from
+     * @return the log lines for the specified node, or an empty list if the
+     *         node is not found, is not a {@link WorkflowRun}, or has no log
+     * @throws IOException if there is an error reading the log
+     */
+    public List<String> extractNodeLog(String nodeId) throws IOException {
+        if (!(run instanceof WorkflowRun)) {
+            return Collections.emptyList();
+        }
+        FlowExecution execution = ((WorkflowRun) run).getExecution();
+        if (execution == null) {
+            return Collections.emptyList();
+        }
+
+        FlowGraphWalker walker = new FlowGraphWalker(execution);
+        for (FlowNode node : walker) {
+            if (!node.getId().equals(nodeId)) {
+                continue;
+            }
+            LogAction logAction = node.getAction(LogAction.class);
+            // catchError + sh(returnStatus:true) + error() fallback
+            if (logAction == null) {
+                FlowNode immediateParent = findImmediateParentWithLog(node);
+                if (immediateParent != null) {
+                    logAction = immediateParent.getAction(LogAction.class);
+                }
+            }
+            if (logAction == null) {
+                return Collections.emptyList();
+            }
+            List<String> stepLog = readLimitedLog(logAction.getLogText(), maxLines);
+            if (stepLog.isEmpty()) {
+                return Collections.emptyList();
+            }
+            addHeaderLog(node, stepLog);
+            setUrl(nodeId);
+            return stepLog;
+        }
+        return Collections.emptyList();
+    }
+
     public ExtractionResult extractFailedStepLog() throws IOException {
         return extractFailedStepLog(true);
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/PipelineLogExtractor.java
@@ -359,8 +359,8 @@ public class PipelineLogExtractor {
         }
 
         FlowNode logNode = target;
-        if (target.getAction(LogAction.class) == null
-                || !hasLogContent(target.getAction(LogAction.class))) {
+        LogAction targetLogAction = target.getAction(LogAction.class);
+        if (targetLogAction == null || !hasLogContent(targetLogAction)) {
             // A block node's failure output lives in the nodes it encloses;
             // a step node's missing log may live in its immediate parent
             // (catchError + sh(returnStatus:true) + error() pattern).
@@ -405,7 +405,8 @@ public class PipelineLogExtractor {
             if (!isEnclosedBy(node, blockId) || !isFailedFlowNode(node)) {
                 continue;
             }
-            if (node.getAction(LogAction.class) != null && hasLogContent(node.getAction(LogAction.class))) {
+            LogAction nodeLogAction = node.getAction(LogAction.class);
+            if (nodeLogAction != null && hasLogContent(nodeLogAction)) {
                 return node;
             }
             FlowNode parent = findImmediateParentWithLog(node);

--- a/src/main/resources/io/jenkins/plugins/explain_error/PipelineGraphViewDecorator/footer.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/PipelineGraphViewDecorator/footer.jelly
@@ -1,0 +1,19 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+    <j:set var="active" value="${it.pluginActive}" />
+    <j:if test="${active}">
+      <j:set var="enabled" value="${it.explainErrorEnabled}" />
+      <j:set var="existingExplanation" value="${it.existingExplanation}" />
+      <j:set var="hasExplanation" value="${existingExplanation != null}" />
+      <j:if test="${enabled or hasExplanation}">
+        <script src="${rootURL}/plugin/explain-error/js/explain-error-graph-view.js" type="text/javascript"/>
+        <j:set var="providerName" value="${it.providerName != null ? it.providerName : 'Unknown'}" />
+        <div id="explain-error-graph-container" class="jenkins-hidden"
+             data-run-url="${it.runUrl}"
+             data-provider-name="${providerName}"
+             data-has-explanation="${hasExplanation}"
+             data-plugin-enabled="${enabled}">
+        </div>
+      </j:if>
+    </j:if>
+</j:jelly>

--- a/src/main/webapp/js/explain-error-graph-view.js
+++ b/src/main/webapp/js/explain-error-graph-view.js
@@ -1,0 +1,398 @@
+/**
+ * Pipeline Graph View integration for the Explain Error plugin.
+ *
+ * Injects an "Explain Error" button into the Pipeline Graph View page
+ * and monitors node selection to enable/disable it based on whether
+ * the selected node represents a failed step.
+ */
+(function () {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var container = document.getElementById('explain-error-graph-container');
+    if (!container) {
+      return;
+    }
+    initGraphViewExplain(container);
+  });
+
+  function initGraphViewExplain(container) {
+    checkGraphBuildStatus(function (buildingStatus) {
+      // Status 0 = SUCCESS, 1 = RUNNING, 2 = FAILURE/UNSTABLE
+      if (buildingStatus === 2) {
+        // Build completed with failure — inject button and start monitoring
+        injectExplainButton();
+        startNodeSelectionMonitor();
+      } else if (buildingStatus === 1) {
+        // Still running — retry after a delay
+        setTimeout(function () {
+          initGraphViewExplain(container);
+        }, 5000);
+      }
+      // Status 0 (SUCCESS) — do nothing
+    });
+  }
+
+  // ---- Build status check ----
+
+  function checkGraphBuildStatus(callback) {
+    var container = document.getElementById('explain-error-graph-container');
+    var basePath = container.dataset.runUrl;
+    var rootURL = document.head.getAttribute('data-rooturl');
+    var url = rootURL + '/' + basePath + 'graph-explain-error/checkBuildStatus';
+
+    var headers = crumb.wrap({
+      'Content-Type': 'application/x-www-form-urlencoded'
+    });
+
+    fetch(url, {
+      method: 'POST',
+      headers: headers,
+      body: ''
+    })
+      .then(function (response) { return response.json(); })
+      .then(function (data) {
+        callback(data.buildingStatus);
+      })
+      .catch(function (error) {
+        console.warn('Error checking build status:', error);
+        callback(2); // Assume failed on error
+      });
+  }
+
+  // ---- Button injection ----
+
+  var explainBtn = null;
+  var currentSelectedNode = null;
+
+  function injectExplainButton() {
+    if (document.querySelector('.explain-error-graph-btn')) {
+      return; // Already injected
+    }
+
+    // Try to find the top-right action bar (contains Run, Replay, etc.)
+    var actionBar = findActionBar();
+    if (!actionBar) {
+      setTimeout(injectExplainButton, 1000);
+      return;
+    }
+
+    var container = document.getElementById('explain-error-graph-container');
+    var providerName = container.dataset.providerName || 'Unknown';
+
+    var btn = document.createElement('button');
+    btn.textContent = 'Explain Error';
+    btn.className = 'jenkins-button explain-error-graph-btn jenkins-hidden';
+    btn.setAttribute('type', 'button');
+    btn.setAttribute('tooltip', 'Provider: ' + providerName);
+    btn.onclick = function () {
+      handleExplainClick();
+    };
+
+    actionBar.appendChild(btn);
+    if (typeof Behaviour !== 'undefined') {
+      Behaviour.applySubtree(actionBar, true);
+    }
+    explainBtn = btn;
+  }
+
+  function findActionBar() {
+    var selectors = [
+      '.jenkins-app-bar__controls',
+      '.jenkins-app-bar .jenkins-app-bar__controls',
+      '#layout-header .page-header__controls'
+    ];
+    for (var i = 0; i < selectors.length; i++) {
+      var el = document.querySelector(selectors[i]);
+      if (el) {
+        return el;
+      }
+    }
+    // Fallback: find or create a container in the app bar
+    var appBar = document.querySelector('.jenkins-app-bar');
+    if (appBar) {
+      var controls = appBar.querySelector('.jenkins-app-bar__controls');
+      if (controls) return controls;
+      var div = document.createElement('div');
+      div.className = 'jenkins-app-bar__controls';
+      appBar.appendChild(div);
+      return div;
+    }
+    return null;
+  }
+
+  // ---- Node selection monitoring ----
+
+  function startNodeSelectionMonitor() {
+    checkCurrentSelection();
+
+    window.addEventListener('popstate', function () {
+      checkCurrentSelection();
+    });
+
+    window.addEventListener('hashchange', function () {
+      checkCurrentSelection();
+    });
+
+    // Polling fallback for SPA-style navigation
+    setInterval(function () {
+      var params = new URLSearchParams(window.location.search);
+      var nodeId = params.get('selected-node');
+      if (nodeId !== currentSelectedNode) {
+        checkCurrentSelection();
+      }
+    }, 1500);
+  }
+
+  function checkCurrentSelection() {
+    var params = new URLSearchParams(window.location.search);
+    var nodeId = params.get('selected-node');
+
+    if (!nodeId || nodeId === currentSelectedNode) {
+      if (!nodeId) {
+        hideButton();
+        currentSelectedNode = null;
+      }
+      return;
+    }
+    currentSelectedNode = nodeId;
+    checkNodeFailedStatus(nodeId);
+  }
+
+  function checkNodeFailedStatus(nodeId) {
+    var container = document.getElementById('explain-error-graph-container');
+    var basePath = container.dataset.runUrl;
+    var rootURL = document.head.getAttribute('data-rooturl');
+    var url = rootURL + '/' + basePath + 'graph-explain-error/checkNodeStatus';
+
+    var headers = crumb.wrap({
+      'Content-Type': 'application/x-www-form-urlencoded'
+    });
+
+    fetch(url, {
+      method: 'POST',
+      headers: headers,
+      body: 'nodeId=' + encodeURIComponent(nodeId)
+    })
+      .then(function (response) { return response.json(); })
+      .then(function (data) {
+        if (data.isFailed) {
+          showButton();
+        } else {
+          hideButton();
+        }
+      })
+      .catch(function (error) {
+        console.warn('Error checking node status:', error);
+        hideButton();
+      });
+  }
+
+  function showButton() {
+    if (explainBtn) {
+      explainBtn.classList.remove('jenkins-hidden');
+    }
+  }
+
+  function hideButton() {
+    if (explainBtn) {
+      explainBtn.classList.add('jenkins-hidden');
+    }
+  }
+
+  // ---- Explain flow ----
+
+  function handleExplainClick() {
+    var container = document.getElementById('explain-error-graph-container');
+    var hasExplanation = container.dataset.hasExplanation === 'true';
+
+    if (hasExplanation) {
+      showExplanationPanel();
+    } else {
+      sendExplainRequest();
+    }
+  }
+
+  function sendExplainRequest(forceNew) {
+    var container = document.getElementById('explain-error-graph-container');
+    var basePath = container.dataset.runUrl;
+    var rootURL = document.head.getAttribute('data-rooturl');
+    var url = rootURL + '/' + basePath + 'graph-explain-error/explainNodeError';
+    var nodeId = currentSelectedNode;
+
+    if (!nodeId) {
+      if (typeof notificationBar !== 'undefined') {
+        notificationBar.show('No failed node selected.', notificationBar.WARNING);
+      }
+      return;
+    }
+
+    var body = 'nodeId=' + encodeURIComponent(nodeId);
+    if (forceNew) {
+      body += '&forceNew=true';
+    }
+
+    var headers = crumb.wrap({
+      'Content-Type': 'application/x-www-form-urlencoded'
+    });
+
+    showSpinner();
+
+    fetch(url, {
+      method: 'POST',
+      headers: headers,
+      body: body
+    })
+      .then(function (response) { return response.text(); })
+      .then(function (text) {
+        var json;
+        try {
+          json = JSON.parse(text);
+        } catch (e) {
+          throw new Error('Explain failed: Jenkins returned an invalid response.');
+        }
+
+        if (json.status === 'success') {
+          showExplanationResult(json.message, json.providerName, json.url);
+        } else {
+          if (typeof notificationBar !== 'undefined') {
+            var level = json.status === 'warning'
+              ? notificationBar.WARNING
+              : notificationBar.ERROR;
+            notificationBar.show(json.message, level);
+          }
+          hideExplanationPanel();
+        }
+      })
+      .catch(function (error) {
+        if (typeof notificationBar !== 'undefined') {
+          notificationBar.show('Error: ' + error.message, notificationBar.ERROR);
+        }
+        hideExplanationPanel();
+      });
+  }
+
+  // ---- Explanation panel ----
+
+  function ensureExplanationPanel() {
+    var panel = document.getElementById('explain-error-graph-panel');
+    if (panel) {
+      return panel;
+    }
+
+    var mainPanel = document.querySelector('#main-panel') || document.body;
+
+    panel = document.createElement('div');
+    panel.id = 'explain-error-graph-panel';
+    panel.className = 'jenkins-hidden';
+    panel.style.margin = '20px';
+
+    var rootURL = document.head.getAttribute('data-rooturl') || '';
+
+    panel.innerHTML =
+      '<div class="jenkins-card">' +
+      '  <div class="jenkins-card__title">' +
+      '    <span id="explain-error-graph-provider">AI Error Explanation</span>' +
+      '    <div class="jenkins-card__controls">' +
+      '      <a href="#" class="jenkins-card__reveal eep-graph-generate-new" tooltip="Generate new explanation">' +
+      '        <img src="' + rootURL + '/plugin/ionicons-api/images/symbol-reload.svg" alt="" style="width:16px;height:16px">' +
+      '      </a>' +
+      '      <a href="#" class="jenkins-card__reveal eep-graph-close" tooltip="Close">' +
+      '        <img src="' + rootURL + '/plugin/ionicons-api/images/symbol-close.svg" alt="" style="width:16px;height:16px">' +
+      '      </a>' +
+      '    </div>' +
+      '  </div>' +
+      '  <div class="jenkins-card__content">' +
+      '    <div id="explain-error-graph-spinner" class="jenkins-hidden" style="text-align:center;padding:20px">' +
+      '      Analyzing error logs...' +
+      '    </div>' +
+      '    <pre id="explain-error-graph-content" class="jenkins-hidden" style="white-space:pre-wrap;word-wrap:break-word;margin-bottom:0"></pre>' +
+      '    <div class="jenkins-!-margin-top-3">' +
+      '      <a id="explain-error-graph-url" href="#" class="jenkins-button jenkins-!-destructive-color jenkins-hidden" target="_self">' +
+      '        View failure output' +
+      '      </a>' +
+      '    </div>' +
+      '  </div>' +
+      '</div>';
+
+    mainPanel.appendChild(panel);
+
+    // Wire up controls
+    panel.querySelector('.eep-graph-generate-new').addEventListener('click', function (e) {
+      e.preventDefault();
+      clearExplanationContent();
+      sendExplainRequest(true);
+    });
+    panel.querySelector('.eep-graph-close').addEventListener('click', function (e) {
+      e.preventDefault();
+      hideExplanationPanel();
+    });
+
+    return panel;
+  }
+
+  function showExplanationPanel() {
+    var container = document.getElementById('explain-error-graph-container');
+    var hasExplanation = container.dataset.hasExplanation === 'true';
+    if (!hasExplanation) {
+      var content = document.getElementById('explain-error-graph-content');
+      if (!content || !content.textContent) {
+        sendExplainRequest();
+        return;
+      }
+    }
+    var panel = ensureExplanationPanel();
+    panel.classList.remove('jenkins-hidden');
+  }
+
+  function hideExplanationPanel() {
+    var panel = document.getElementById('explain-error-graph-panel');
+    if (panel) {
+      panel.classList.add('jenkins-hidden');
+    }
+  }
+
+  function showSpinner() {
+    var panel = ensureExplanationPanel();
+    panel.classList.remove('jenkins-hidden');
+    document.getElementById('explain-error-graph-spinner').classList.remove('jenkins-hidden');
+    document.getElementById('explain-error-graph-content').classList.add('jenkins-hidden');
+    document.getElementById('explain-error-graph-url').classList.add('jenkins-hidden');
+  }
+
+  function showExplanationResult(message, providerName, url) {
+    var panel = ensureExplanationPanel();
+    panel.classList.remove('jenkins-hidden');
+
+    var spinner = document.getElementById('explain-error-graph-spinner');
+    var content = document.getElementById('explain-error-graph-content');
+    var urlLink = document.getElementById('explain-error-graph-url');
+    var providerSpan = document.getElementById('explain-error-graph-provider');
+
+    spinner.classList.add('jenkins-hidden');
+    content.textContent = message;
+    content.classList.remove('jenkins-hidden');
+
+    if (url) {
+      urlLink.href = url;
+      urlLink.classList.remove('jenkins-hidden');
+    }
+
+    if (providerName) {
+      providerSpan.textContent = 'AI Error Explanation (' + providerName + ')';
+    }
+
+    // Update container cache flag
+    var container = document.getElementById('explain-error-graph-container');
+    container.dataset.hasExplanation = 'true';
+  }
+
+  function clearExplanationContent() {
+    var content = document.getElementById('explain-error-graph-content');
+    if (content) {
+      content.classList.add('jenkins-hidden');
+      content.textContent = '';
+    }
+  }
+
+})();

--- a/src/main/webapp/js/explain-error-graph-view.js
+++ b/src/main/webapp/js/explain-error-graph-view.js
@@ -231,14 +231,7 @@
   // ---- Explain flow ----
 
   function handleExplainClick() {
-    var container = document.getElementById('explain-error-graph-container');
-    var hasExplanation = container.dataset.hasExplanation === 'true';
-
-    if (hasExplanation) {
-      showExplanationPanel();
-    } else {
-      sendExplainRequest();
-    }
+    showExplanationPanel();
   }
 
   function sendExplainRequest(forceNew) {
@@ -360,14 +353,12 @@
   }
 
   function showExplanationPanel() {
-    var container = document.getElementById('explain-error-graph-container');
-    var hasExplanation = container.dataset.hasExplanation === 'true';
-    if (!hasExplanation) {
-      var content = document.getElementById('explain-error-graph-content');
-      if (!content || !content.textContent) {
-        sendExplainRequest();
-        return;
-      }
+    var content = document.getElementById('explain-error-graph-content');
+    if (!content || !content.textContent) {
+      // Nothing rendered yet — fetch from the server, which returns the
+      // cached explanation when one exists and generates one otherwise.
+      sendExplainRequest();
+      return;
     }
     var panel = ensureExplanationPanel();
     panel.classList.remove('jenkins-hidden');

--- a/src/main/webapp/js/explain-error-graph-view.js
+++ b/src/main/webapp/js/explain-error-graph-view.js
@@ -123,25 +123,53 @@
 
   // ---- Node selection monitoring ----
 
+  /**
+   * Intercept history.pushState and history.replaceState to detect URL changes
+   * that don't fire popstate events (used by Pipeline Graph View for node
+   * selection).
+   */
+  function patchHistory() {
+    var pushState = history.pushState;
+    var replaceState = history.replaceState;
+
+    function onUrlChange() {
+      window.dispatchEvent(new Event('urlchange'));
+    }
+
+    history.pushState = function () {
+      pushState.apply(history, arguments);
+      onUrlChange();
+    };
+    history.replaceState = function () {
+      replaceState.apply(history, arguments);
+      onUrlChange();
+    };
+  }
+
   function startNodeSelectionMonitor() {
+    patchHistory();
+
+    // Check initial selection
     checkCurrentSelection();
 
+    // Listen for browser back/forward
     window.addEventListener('popstate', function () {
       checkCurrentSelection();
     });
 
-    window.addEventListener('hashchange', function () {
+    // Listen for history.pushState / replaceState
+    window.addEventListener('urlchange', function () {
       checkCurrentSelection();
     });
 
-    // Polling fallback for SPA-style navigation
+    // Low-frequency polling fallback (in case other mechanisms change the URL)
     setInterval(function () {
       var params = new URLSearchParams(window.location.search);
       var nodeId = params.get('selected-node');
       if (nodeId !== currentSelectedNode) {
         checkCurrentSelection();
       }
-    }, 1500);
+    }, 500);
   }
 
   function checkCurrentSelection() {

--- a/src/test/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorActionTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorActionTest.java
@@ -4,13 +4,22 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Result;
 import io.jenkins.plugins.explain_error.provider.TestProvider;
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 import net.sf.json.JSONObject;
 import org.htmlunit.HttpMethod;
 import org.htmlunit.Page;
 import org.htmlunit.WebRequest;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.FailureBuilder;
@@ -247,5 +256,146 @@ class GraphViewExplainErrorActionTest {
             assertTrue(responseJson.getString("message").contains("Second call"));
             assertEquals(2, provider.getCallCount());
         }
+    }
+
+    @Test
+    void testIsFailedNodeMultiStagePipeline() throws Exception {
+        WorkflowRun pipelineRun = buildMinimalMultiStagePipeline("multi-stage");
+        GraphViewExplainErrorAction pipelineAction = new GraphViewExplainErrorAction(pipelineRun);
+
+        FlowNode stageA = findStageNode(pipelineRun, "A");
+        FlowNode stageB = findStageNode(pipelineRun, "B");
+        FlowNode failedStep = findStepNode(pipelineRun, true);
+        FlowNode successfulStep = findStepNode(pipelineRun, false);
+
+        assertTrue(pipelineAction.isFailedNode(stageB.getId()),
+                "failed stage must be reported as failed");
+        assertTrue(pipelineAction.isFailedNode(failedStep.getId()),
+                "failing step must be reported as failed");
+        assertFalse(pipelineAction.isFailedNode(stageA.getId()),
+                "successful stage that ran before the failure must not be reported as failed");
+        assertFalse(pipelineAction.isFailedNode(successfulStep.getId()),
+                "successful step that ran before the failure must not be reported as failed");
+    }
+
+    @Test
+    void testExtractNodeLogFromStageBlockNode() throws Exception {
+        WorkflowRun pipelineRun = buildMultiStagePipeline("multi-stage-log");
+        PipelineLogExtractor extractor = new PipelineLogExtractor(pipelineRun, 200);
+
+        List<String> failedStageLog = extractor.extractNodeLog(findStageNode(pipelineRun, "B").getId());
+        assertFalse(failedStageLog.isEmpty(),
+                "failed stage must yield the enclosed failing step's log");
+        assertTrue(failedStageLog.stream().anyMatch(
+                        line -> line.contains("boom") || line.contains("stage B log")),
+                "stage log must contain output from inside the failed stage, got: " + failedStageLog);
+        assertFalse(failedStageLog.stream().anyMatch(line -> line.contains("hello from A")),
+                "stage log must not leak output from a preceding stage");
+
+        List<String> successfulStageLog = extractor.extractNodeLog(findStageNode(pipelineRun, "A").getId());
+        assertTrue(successfulStageLog.isEmpty(),
+                "successful stage has no failing content and must not fall back to a predecessor's log");
+    }
+
+    @Test
+    void testExplainNodeErrorOnStageNode() throws Exception {
+        WorkflowRun pipelineRun = buildMultiStagePipeline("multi-stage-explain");
+        String stageBId = findStageNode(pipelineRun, "B").getId();
+
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl()
+                    + pipelineRun.getUrl() + "graph-explain-error/explainNodeError");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            request.setRequestParameters(java.util.Collections.singletonList(
+                new org.htmlunit.util.NameValuePair("nodeId", stageBId)
+            ));
+            Page page = client.getPage(request);
+            JSONObject responseJson = JSONObject.fromObject(page.getWebResponse().getContentAsString());
+            assertEquals("success", responseJson.getString("status"));
+            String sentLogs = provider.getLastErrorLogs();
+            assertTrue(sentLogs.contains("boom") || sentLogs.contains("stage B log"),
+                    "provider must receive log output from inside the failed stage, got: " + sentLogs);
+            assertFalse(sentLogs.contains("hello from A"),
+                    "provider must not receive output leaked from a preceding stage");
+        }
+    }
+
+    @Test
+    void testExplainNodeErrorCachedResponseIncludesUrl() throws Exception {
+        WorkflowRun pipelineRun = buildMultiStagePipeline("multi-stage-cache-url");
+        String failedStepId = findStepNode(pipelineRun, true).getId();
+
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl()
+                    + pipelineRun.getUrl() + "graph-explain-error/explainNodeError");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            request.setRequestParameters(java.util.Collections.singletonList(
+                new org.htmlunit.util.NameValuePair("nodeId", failedStepId)
+            ));
+
+            // First call generates and stores the explanation
+            client.getPage(request);
+            ErrorExplanationAction explanationAction =
+                    pipelineRun.getAction(ErrorExplanationAction.class);
+            assertNotNull(explanationAction);
+            assertNotNull(explanationAction.getUrlString());
+
+            // Second call is a cache hit and must still carry the stored URL
+            Page page = client.getPage(request);
+            JSONObject responseJson = JSONObject.fromObject(page.getWebResponse().getContentAsString());
+            assertEquals("success", responseJson.getString("status"));
+            assertTrue(responseJson.getString("message").contains("previously generated"));
+            assertEquals(explanationAction.getUrlString(), responseJson.getString("url"),
+                    "cached response must carry the stored explanation URL");
+        }
+    }
+
+    /**
+     * Two-stage pipeline where the second stage fails. Stage B contains an
+     * {@code echo} before the {@code error} step so that log extraction has
+     * in-stage output to fall back to when the {@code error} step node itself
+     * carries no log.
+     */
+    private WorkflowRun buildMultiStagePipeline(String name) throws Exception {
+        return buildPipeline(name,
+                "stage('A') { echo 'hello from A' }\n"
+                + "stage('B') { echo 'stage B log'; error 'boom' }");
+    }
+
+    /**
+     * Minimal two-stage pipeline: the only successful step is stage A's
+     * {@code echo}, so {@link #findStepNode} can unambiguously locate a
+     * successful step that ran before the failure.
+     */
+    private WorkflowRun buildMinimalMultiStagePipeline(String name) throws Exception {
+        return buildPipeline(name,
+                "stage('A') { echo 'hello from A' }\n"
+                + "stage('B') { error 'boom' }");
+    }
+
+    private WorkflowRun buildPipeline(String name, String script) throws Exception {
+        WorkflowJob job = rule.jenkins.createProject(WorkflowJob.class, name);
+        job.setDefinition(new CpsFlowDefinition(script, true));
+        WorkflowRun pipelineRun = job.scheduleBuild2(0).get();
+        rule.assertBuildStatus(Result.FAILURE, pipelineRun);
+        return pipelineRun;
+    }
+
+    private static FlowNode findStageNode(WorkflowRun pipelineRun, String stageName) {
+        for (FlowNode node : new FlowGraphWalker(pipelineRun.getExecution())) {
+            if (node.getAction(LabelAction.class) != null && stageName.equals(node.getDisplayName())) {
+                return node;
+            }
+        }
+        throw new AssertionError("Stage node not found: " + stageName);
+    }
+
+    private static FlowNode findStepNode(WorkflowRun pipelineRun, boolean failed) {
+        for (FlowNode node : new FlowGraphWalker(pipelineRun.getExecution())) {
+            if (node instanceof StepAtomNode && (node.getError() != null) == failed) {
+                return node;
+            }
+        }
+        throw new AssertionError("Step node not found (failed=" + failed + ")");
     }
 }

--- a/src/test/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorActionTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorActionTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
-import io.jenkins.plugins.explain_error.provider.TestProvider;
+import io.jenkins.plugins.explain_error.provider.FakeAIProvider;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
@@ -33,7 +33,7 @@ class GraphViewExplainErrorActionTest {
     private GraphViewExplainErrorAction action;
     private FreeStyleBuild build;
     private JenkinsRule rule;
-    private final TestProvider provider = new TestProvider();
+    private final FakeAIProvider provider = new FakeAIProvider();
     FreeStyleProject project;
 
     @BeforeEach

--- a/src/test/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorActionTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/GraphViewExplainErrorActionTest.java
@@ -1,0 +1,251 @@
+package io.jenkins.plugins.explain_error;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import io.jenkins.plugins.explain_error.provider.TestProvider;
+import java.io.IOException;
+import java.net.URL;
+import net.sf.json.JSONObject;
+import org.htmlunit.HttpMethod;
+import org.htmlunit.Page;
+import org.htmlunit.WebRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.FailureBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class GraphViewExplainErrorActionTest {
+
+    private GraphViewExplainErrorAction action;
+    private FreeStyleBuild build;
+    private JenkinsRule rule;
+    private final TestProvider provider = new TestProvider();
+    FreeStyleProject project;
+
+    @BeforeEach
+    void setUp(JenkinsRule jenkins) throws Exception {
+        this.rule = jenkins;
+        rule.jenkins.setCrumbIssuer(null);
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        config.setAiProvider(provider);
+        project = jenkins.createFreeStyleProject("test");
+        build = jenkins.buildAndAssertSuccess(project);
+        action = new GraphViewExplainErrorAction(build);
+    }
+
+    @Test
+    void testBasicFunctionality() {
+        assertNotNull(action);
+        assertEquals(build, action.getRun());
+        assertNull(action.getIconFileName());
+        assertNull(action.getDisplayName());
+        assertEquals("graph-explain-error", action.getUrlName());
+    }
+
+    @Test
+    void testCreateCachedResponse() {
+        String originalExplanation = "This is the original AI explanation.";
+        String cachedResponse = action.createCachedResponse(originalExplanation);
+
+        assertNotNull(cachedResponse);
+        assertTrue(cachedResponse.contains(originalExplanation));
+        assertTrue(cachedResponse.contains("previously generated explanation"));
+        assertTrue(cachedResponse.contains("Generate New"));
+    }
+
+    @Test
+    void testIsFailedNodeNullNodeId() {
+        assertFalse(action.isFailedNode(null));
+    }
+
+    @Test
+    void testIsFailedNodeBlankNodeId() {
+        assertFalse(action.isFailedNode(""));
+        assertFalse(action.isFailedNode("   "));
+    }
+
+    @Test
+    void testIsFailedNodeNonWorkflowRun() {
+        assertFalse(action.isFailedNode("123"));
+    }
+
+    @Test
+    void testCheckBuildStatus() throws IOException {
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl()
+                    + build.getUrl() + "graph-explain-error/checkBuildStatus");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            Page page = client.getPage(request);
+            String content = page.getWebResponse().getContentAsString();
+            JSONObject responseJson = JSONObject.fromObject(content);
+            assertEquals(0, responseJson.getInt("buildingStatus"));
+        }
+    }
+
+    @Test
+    void testCheckBuildStatusRunning() throws Exception {
+        project.getBuildersList().add(new SleepBuilder(2000));
+        FreeStyleBuild runningBuild = project.scheduleBuild2(0).waitForStart();
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl()
+                    + runningBuild.getUrl() + "graph-explain-error/checkBuildStatus");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            Page page = client.getPage(request);
+            String content = page.getWebResponse().getContentAsString();
+            JSONObject responseJson = JSONObject.fromObject(content);
+            assertEquals(1, responseJson.getInt("buildingStatus"));
+        }
+    }
+
+    @Test
+    void testCheckBuildStatusFailed() throws Exception {
+        project.getBuildersList().clear();
+        project.getBuildersList().add(new FailureBuilder());
+        FreeStyleBuild failedBuild = project.scheduleBuild2(0).get();
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl()
+                    + failedBuild.getUrl() + "graph-explain-error/checkBuildStatus");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            Page page = client.getPage(request);
+            String content = page.getWebResponse().getContentAsString();
+            JSONObject responseJson = JSONObject.fromObject(content);
+            assertEquals(2, responseJson.getInt("buildingStatus"));
+        }
+    }
+
+    @Test
+    void testExplainNodeErrorNoNodeId() throws IOException {
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl()
+                    + build.getUrl() + "graph-explain-error/explainNodeError");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            Page page = client.getPage(request);
+            String content = page.getWebResponse().getContentAsString();
+            JSONObject responseJson = JSONObject.fromObject(content);
+            assertEquals("error", responseJson.getString("status"));
+            assertTrue(responseJson.getString("message").contains("No node selected"));
+        }
+    }
+
+    @Test
+    void testExplainNodeErrorNonExistentNode() throws IOException {
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl()
+                    + build.getUrl() + "graph-explain-error/explainNodeError");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            request.setRequestParameters(java.util.Collections.singletonList(
+                new org.htmlunit.util.NameValuePair("nodeId", "99999")
+            ));
+            Page page = client.getPage(request);
+            String content = page.getWebResponse().getContentAsString();
+            JSONObject responseJson = JSONObject.fromObject(content);
+            assertEquals("error", responseJson.getString("status"));
+            assertTrue(responseJson.getString("message").contains("No log output found"));
+        }
+    }
+
+    @Test
+    void testExplainNodeErrorSuccess() throws Exception {
+        // Use a Pipeline (WorkflowRun) to get real flow graph nodes
+        org.jenkinsci.plugins.workflow.job.WorkflowJob job =
+                rule.jenkins.createProject(org.jenkinsci.plugins.workflow.job.WorkflowJob.class, "pipeline-test");
+        job.setDefinition(new org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition(
+            "node { sh 'echo hello' }", true));
+        org.jenkinsci.plugins.workflow.job.WorkflowRun pipelineRun =
+                rule.buildAndAssertSuccess(job);
+
+        GraphViewExplainErrorAction pipelineAction = new GraphViewExplainErrorAction(pipelineRun);
+
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl()
+                    + pipelineRun.getUrl() + "graph-explain-error/explainNodeError");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            // Node ID "3" is typically the shell step in this simple pipeline
+            request.setRequestParameters(java.util.Collections.singletonList(
+                new org.htmlunit.util.NameValuePair("nodeId", "3")
+            ));
+            Page page = client.getPage(request);
+            String content = page.getWebResponse().getContentAsString();
+            JSONObject responseJson = JSONObject.fromObject(content);
+            assertEquals("success", responseJson.getString("status"));
+            assertTrue(responseJson.getString("message").contains("Request was successful"));
+        }
+    }
+
+    @Test
+    void testExplainNodeErrorCacheHit() throws Exception {
+        org.jenkinsci.plugins.workflow.job.WorkflowJob job =
+                rule.jenkins.createProject(org.jenkinsci.plugins.workflow.job.WorkflowJob.class, "pipeline-cache");
+        job.setDefinition(new org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition(
+            "node { sh 'echo hello' }", true));
+        org.jenkinsci.plugins.workflow.job.WorkflowRun pipelineRun =
+                rule.buildAndAssertSuccess(job);
+
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl()
+                    + pipelineRun.getUrl() + "graph-explain-error/explainNodeError");
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            request.setRequestParameters(java.util.Collections.singletonList(
+                new org.htmlunit.util.NameValuePair("nodeId", "3")
+            ));
+
+            // First call — generates explanation
+            client.getPage(request);
+            ErrorExplanationAction explanationAction =
+                    pipelineRun.getAction(ErrorExplanationAction.class);
+            assertNotNull(explanationAction);
+            assertEquals("Summary: Request was successful\n", explanationAction.getExplanation());
+
+            // Second call — should hit cache
+            provider.setAnswerMessage("Second call");
+            Page page = client.getPage(request);
+            String content = page.getWebResponse().getContentAsString();
+            JSONObject responseJson = JSONObject.fromObject(content);
+            assertEquals("success", responseJson.getString("status"));
+            // Should still be the original message (cached)
+            assertTrue(responseJson.getString("message").contains("Request was successful"));
+            // Should not have made a second provider call
+            assertEquals(1, provider.getCallCount());
+        }
+    }
+
+    @Test
+    void testExplainNodeErrorForceNew() throws Exception {
+        org.jenkinsci.plugins.workflow.job.WorkflowJob job =
+                rule.jenkins.createProject(org.jenkinsci.plugins.workflow.job.WorkflowJob.class, "pipeline-force");
+        job.setDefinition(new org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition(
+            "node { sh 'echo hello' }", true));
+        org.jenkinsci.plugins.workflow.job.WorkflowRun pipelineRun =
+                rule.buildAndAssertSuccess(job);
+
+        try (JenkinsRule.WebClient client = rule.createWebClient()) {
+            URL url = new URL(rule.jenkins.getRootUrl()
+                    + pipelineRun.getUrl() + "graph-explain-error/explainNodeError");
+
+            // First call
+            WebRequest request = new WebRequest(url, HttpMethod.POST);
+            request.setRequestParameters(java.util.Collections.singletonList(
+                new org.htmlunit.util.NameValuePair("nodeId", "3")
+            ));
+            client.getPage(request);
+
+            // Second call with forceNew
+            provider.setAnswerMessage("Second call");
+            request.setRequestParameters(java.util.Arrays.asList(
+                new org.htmlunit.util.NameValuePair("nodeId", "3"),
+                new org.htmlunit.util.NameValuePair("forceNew", "true")
+            ));
+            Page page = client.getPage(request);
+            String content = page.getWebResponse().getContentAsString();
+            JSONObject responseJson = JSONObject.fromObject(content);
+            assertEquals("success", responseJson.getString("status"));
+            assertTrue(responseJson.getString("message").contains("Second call"));
+            assertEquals(2, provider.getCallCount());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **Explain Error** button to the Pipeline Graph View page that appears when a user selects a failed node. The feature reuses the existing `ErrorExplanationAction` caching mechanism — showing a cached explanation when available, generating a new AI explanation otherwise.

## Changes

### New files

| File | Description |
|---|---|
| `GraphViewExplainErrorAction.java` | `RunAction2` providing AJAX endpoints: `doCheckBuildStatus`, `doCheckNodeStatus`, `doExplainNodeError` |
| `GraphViewExplainErrorActionFactory.java` | `TransientActionFactory` that injects the action into all runs (only when `pipeline-graph-view` is installed) |
| `PipelineGraphViewDecorator.java` | `PageDecorator` that injects JS/CSS into the `*/stages` page |
| `explain-error-graph-view.js` | Frontend logic: monitors `?selected-node=` URL parameter changes, shows/hides the Explain button based on node failure status, displays explanation panel with regenerate/close controls |
| `GraphViewExplainErrorActionTest.java` | 13 unit tests covering build status, node status queries, cache hits, force-new generation |

### Modified files

| File | Change |
|---|---|
| `PipelineLogExtractor.java` | Added `extractNodeLog(String nodeId)` method to extract log output from a specific flow node by its ID |

## Behavior

1. **Button placement**: The button is injected into the top-right action bar (next to Run/Replay buttons) on the Pipeline Graph View (`*/stages`) page.

2. **Activation logic**:
   - The build must have completed with a non-SUCCESS result.
   - Only when the user clicks a **failed** node (one with `ErrorAction` or a descendant with `ErrorAction`) does the button become visible.
   - Clicking a green (successful) node hides the button.

3. **Caching**: Same as the existing Console integration:
   - If an `ErrorExplanationAction` exists for the run, it is returned directly (with a "previously generated" note).
   - `forceNew=true` triggers a fresh AI call.
   - The "View failure output" link deep-links to the selected node in the graph view.

4. **Graceful degradation**: When `pipeline-graph-view` is not installed, no action is injected and no JS is loaded.

## Testing

```
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
```

Full `mvn verify` passes with zero SpotBugs errors.