### PR TITLE
feat: add GlobalRunListener to auto-explain failed builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## 🎥 Demo
 
-👉 [Watch the hands-on demo on YouTube](https://youtu.be/rPI9PMeDQ2o?si=YMeprtSz9VmqglCL) - setup, run, and see how AI explains your Jenkins job failures.
+👉 [Watch the hands-on demo on YouTube](https://youtu.be/rPI9PMeDQ2o?si=YMeprtSz9VmqglCL) — setup, run, and see how AI explains your Jenkins job failures.
 
 ---
 
@@ -31,9 +31,9 @@
 
 Tired of digging through long Jenkins logs to understand what went wrong?
 
-**Explain Error Plugin** leverages AI to automatically interpret job and pipeline failures-saving you time and helping you fix issues faster.
+**Explain Error Plugin** leverages AI to automatically interpret job and pipeline failures—saving you time and helping you fix issues faster.
 
-Whether it's a compilation error, test failure, or deployment hiccup, this plugin turns confusing logs into human-readable insights.
+Whether it’s a compilation error, test failure, or deployment hiccup, this plugin turns confusing logs into human-readable insights.
 
 ## Key Features
 
@@ -41,10 +41,10 @@ Whether it's a compilation error, test failure, or deployment hiccup, this plugi
 * **Pipeline-ready** with a simple `explainError()` step
 * **Automatic explanation on failure** — failed builds are explained without any pipeline change when the global toggle is enabled
 * **Workspace Context** *(opt-in)* — include selected workspace files for more accurate explanations
-* **AI auto-fix** *(experimental)* - automatically opens a pull request on GitHub, GitLab, or Bitbucket with AI-generated code changes when a build fails
+* **AI auto-fix** *(experimental)* — automatically opens a pull request on GitHub, GitLab, or Bitbucket with AI-generated code changes when a build fails
 * **AI-powered explanations** via Anthropic Claude, AWS Bedrock, Azure OpenAI, DeepSeek, Google Gemini, LangGraph, Microsoft Foundry, Ollama, OpenAI GPT models, Qwen, or generic Okta-authenticated company AI gateways
 * **Folder-level configuration** so teams can use project-specific settings
-* **Smart provider management** - LangChain4j handles most providers automatically
+* **Smart provider management** — LangChain4j handles most providers automatically
 * **Customizable**: set provider, model, API endpoint, Okta token flow settings, log filters, and more
 
 [^1]: *Enterprise-ready API endpoints support private gateways, company-hosted AI services, and air-gapped environments.*
@@ -81,7 +81,7 @@ Whether it's a compilation error, test failure, or deployment hiccup, this plugi
 | **API Key** | Your AI provider API key | Used by OpenAI, Microsoft Foundry, Anthropic, Gemini, DeepSeek, and Qwen providers |
 | **API URL** | AI service endpoint | **Leave empty** for official APIs where supported. **Required for Custom Okta AI and Ollama providers.** Optional Bedrock Runtime endpoint override for private VPC endpoints. |
 | **AI Model** | Model to use for analysis | *Required*.  Specify the model name offered by your selected AI provider |
-| **Temperature** | Creativity control (0.0-2.0). Leave empty to use the provider default. | *Optional* |
+| **Temperature** | Creativity control (0.0–2.0). Leave empty to use the provider default. | *Optional* |
 | **Language** | Language for AI explanations (e.g. `English`, `中文`, `日本語`). Can be overridden at folder and step level. | `English` |
 | **Custom Context** | Additional instructions or context for the AI (e.g., KB article links, organization-specific troubleshooting steps) | *Optional*. Can be overridden at folder and step level. |
 | **Automatically explain failed builds** | When enabled (and AI Error Explanation is active), all failed builds (result `FAILURE`) are automatically explained without any pipeline change. Builds already explained via `explainError()` step are skipped. | Disabled |
@@ -99,10 +99,10 @@ Support for folder-level overrides allows different teams to use their own AI pr
 
 1. Click **Configure** on any folder
 2. Expand **"Explain Error Configuration"** and set:
-   - **AI Provider** - overrides the global provider
-   - **Temperature** - overrides the global temperature
-   - **Language** - overrides the global language
-   - **Custom Context** - overrides the global custom context
+   - **AI Provider** — overrides the global provider
+   - **Temperature** — overrides the global temperature
+   - **Language** — overrides the global language
+   - **Custom Context** — overrides the global custom context
 
 *All folder settings inherit from parent folders and override global defaults. Step-level settings take precedence over both.*
 
@@ -304,8 +304,8 @@ This allows you to manage the plugin configuration alongside your other Jenkins 
 
 ### AWS Bedrock
 - **Models**: `anthropic.claude-3-5-sonnet-20240620-v1:0`, `eu.anthropic.claude-3-5-sonnet-20240620-v1:0` (EU cross-region), `meta.llama3-8b-instruct-v1:0`, `us.amazon.nova-lite-v1:0`, etc.
-- **API Key**: Not required - uses AWS credential chain (instance profiles, environment variables, etc.)
-- **Region**: AWS region (e.g., `us-east-1`, `eu-west-1`). Optional - defaults to AWS SDK region resolution
+- **API Key**: Not required — uses AWS credential chain (instance profiles, environment variables, etc.)
+- **Region**: AWS region (e.g., `us-east-1`, `eu-west-1`). Optional — defaults to AWS SDK region resolution
 - **Endpoint**: Optional Bedrock Runtime endpoint override for VPC endpoints or private AWS-compatible endpoints. Host-only values default to HTTPS
 - **Cross-account role**: Optional IAM role ARN. Jenkins uses its base AWS credentials to call STS AssumeRole, then invokes Bedrock with the temporary credentials
 - **Best for**: Enterprise AWS environments, data residency compliance, using Claude models with AWS infrastructure
@@ -341,7 +341,7 @@ This allows you to manage the plugin configuration alongside your other Jenkins 
 
 ### LangGraph
 - **Models**: The assistant UUID or registered graph name to invoke (e.g. `my-agent`)
-- **API Key**: LangGraph Platform API key - passed as the `x-api-key` header
+- **API Key**: LangGraph Platform API key — passed as the `x-api-key` header
 - **Endpoint**: Base URL of your LangGraph Platform deployment, e.g. `https://your-deployment.langchain.com`
 - **Best for**: Custom LangGraph agents deployed on the LangGraph Platform that expose a `/runs/wait` endpoint
 
@@ -407,13 +407,13 @@ post {
         script {
             // Capture the AI explanation
             def explanation = explainError()
-
+            
             // Use it in notifications
             slackSend(
                 color: 'danger',
                 message: "Build Failed!\n\nAI Analysis:\n${explanation}"
             )
-
+            
             // Or send to email, webhook, etc.
             emailext body: "Error Analysis:\n${explanation}"
         }
@@ -428,7 +428,7 @@ post {
 | **maxLines** | Max log lines to analyze (trims from the end)       | `100`                 |
 | **logPattern** | Regex pattern to filter relevant log lines        | `''` (no filtering)   |
 | **language** | Language for the explanation                        | `'English'`           |
-| **temperature** | Creativity control (0.0-2.0). Leave empty to use the folder or global setting. | Uses folder/global configuration |
+| **temperature** | Creativity control (0.0–2.0). Leave empty to use the folder or global setting. | Uses folder/global configuration |
 | **customContext** | Additional instructions or context for the AI. Overrides global custom context if specified. | Uses global configuration |
 | **collectDownstreamLogs** | Whether to include logs from failed downstream jobs discovered via the `build` step or `Cause.UpstreamCause` | `false` |
 | **downstreamJobPattern** | Regular expression matched against downstream job full names. Used only when downstream collection is enabled. | `''` (collect none) |
@@ -491,9 +491,9 @@ Output appears in the sidebar of the failed job.
 
 ### Auto-Fix: Automatic Pull Request Creation *(Experimental)*
 
-> ⚠️ **Experimental feature.** Auto-fix is opt-in and disabled by default. AI-generated diffs can be incorrect or incomplete - always review the PR before merging. See [docs/auto-fix.md](docs/auto-fix.md) for a full setup guide, supported SCM providers, limitations, and best practices.
+> ⚠️ **Experimental feature.** Auto-fix is opt-in and disabled by default. AI-generated diffs can be incorrect or incomplete — always review the PR before merging. See [docs/auto-fix.md](docs/auto-fix.md) for a full setup guide, supported SCM providers, limitations, and best practices.
 
-When `autoFix: true` is set, the plugin goes one step further than explaining the error - it asks the AI to generate a code fix, commits the changes to a new branch, and opens a pull request for your review.
+When `autoFix: true` is set, the plugin goes one step further than explaining the error — it asks the AI to generate a code fix, commits the changes to a new branch, and opens a pull request for your review.
 
 **Quick start:**
 
@@ -556,7 +556,7 @@ The AI will only propose changes to files matching the glob patterns. Any attemp
 
 Works with Freestyle, Declarative, or any job type.
 
-1. Go to the failed build's console output
+1. Go to the failed build’s console output
 2. Click **Explain Error** button in the top
 3. View results directly under the button
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## 🎥 Demo
 
-👉 [Watch the hands-on demo on YouTube](https://youtu.be/rPI9PMeDQ2o?si=YMeprtSz9VmqglCL) — setup, run, and see how AI explains your Jenkins job failures.
+👉 [Watch the hands-on demo on YouTube](https://youtu.be/rPI9PMeDQ2o?si=YMeprtSz9VmqglCL) - setup, run, and see how AI explains your Jenkins job failures.
 
 ---
 
@@ -31,19 +31,20 @@
 
 Tired of digging through long Jenkins logs to understand what went wrong?
 
-**Explain Error Plugin** leverages AI to automatically interpret job and pipeline failures—saving you time and helping you fix issues faster.
+**Explain Error Plugin** leverages AI to automatically interpret job and pipeline failures-saving you time and helping you fix issues faster.
 
-Whether it’s a compilation error, test failure, or deployment hiccup, this plugin turns confusing logs into human-readable insights.
+Whether it's a compilation error, test failure, or deployment hiccup, this plugin turns confusing logs into human-readable insights.
 
 ## Key Features
 
 * **One-click error analysis** on any console output
 * **Pipeline-ready** with a simple `explainError()` step
+* **Automatic explanation on failure** — failed builds are explained without any pipeline change when the global toggle is enabled
 * **Workspace Context** *(opt-in)* — include selected workspace files for more accurate explanations
-* **AI auto-fix** *(experimental)* — automatically opens a pull request on GitHub, GitLab, or Bitbucket with AI-generated code changes when a build fails
+* **AI auto-fix** *(experimental)* - automatically opens a pull request on GitHub, GitLab, or Bitbucket with AI-generated code changes when a build fails
 * **AI-powered explanations** via Anthropic Claude, AWS Bedrock, Azure OpenAI, DeepSeek, Google Gemini, LangGraph, Microsoft Foundry, Ollama, OpenAI GPT models, Qwen, or generic Okta-authenticated company AI gateways
 * **Folder-level configuration** so teams can use project-specific settings
-* **Smart provider management** — LangChain4j handles most providers automatically
+* **Smart provider management** - LangChain4j handles most providers automatically
 * **Customizable**: set provider, model, API endpoint, Okta token flow settings, log filters, and more
 
 [^1]: *Enterprise-ready API endpoints support private gateways, company-hosted AI services, and air-gapped environments.*
@@ -80,9 +81,10 @@ Whether it’s a compilation error, test failure, or deployment hiccup, this plu
 | **API Key** | Your AI provider API key | Used by OpenAI, Microsoft Foundry, Anthropic, Gemini, DeepSeek, and Qwen providers |
 | **API URL** | AI service endpoint | **Leave empty** for official APIs where supported. **Required for Custom Okta AI and Ollama providers.** Optional Bedrock Runtime endpoint override for private VPC endpoints. |
 | **AI Model** | Model to use for analysis | *Required*.  Specify the model name offered by your selected AI provider |
-| **Temperature** | Creativity control (0.0–2.0). Leave empty to use the provider default. | *Optional* |
+| **Temperature** | Creativity control (0.0-2.0). Leave empty to use the provider default. | *Optional* |
 | **Language** | Language for AI explanations (e.g. `English`, `中文`, `日本語`). Can be overridden at folder and step level. | `English` |
 | **Custom Context** | Additional instructions or context for the AI (e.g., KB article links, organization-specific troubleshooting steps) | *Optional*. Can be overridden at folder and step level. |
+| **Automatically explain failed builds** | When enabled (and AI Error Explanation is active), all failed/unstable builds are automatically explained without any pipeline change. Builds already explained via `explainError()` step are skipped. | Disabled |
 
 `Custom Okta AI` adds provider-specific fields for `Okta Token URL`, `Client ID`, `Client Secret`, and optional `Scope`, `API Version`, `App Key`, and custom access-token header settings. This is intended for generic company AI gateways that require an OAuth client-credentials exchange before the chat call.
 
@@ -97,10 +99,10 @@ Support for folder-level overrides allows different teams to use their own AI pr
 
 1. Click **Configure** on any folder
 2. Expand **"Explain Error Configuration"** and set:
-   - **AI Provider** — overrides the global provider
-   - **Temperature** — overrides the global temperature
-   - **Language** — overrides the global language
-   - **Custom Context** — overrides the global custom context
+   - **AI Provider** - overrides the global provider
+   - **Temperature** - overrides the global temperature
+   - **Language** - overrides the global language
+   - **Custom Context** - overrides the global custom context
 
 *All folder settings inherit from parent folders and override global defaults. Step-level settings take precedence over both.*
 
@@ -283,6 +285,7 @@ unclassified:
   explainError:
     # ... your provider configuration above ...
     enableExplanation: true
+    # enableAutoExplainOnFailure: true # Optional, automatically explain failed builds without pipeline changes
     # temperature: 0.7 # Optional, leave empty for provider default
     # language: "English" # Optional, defaults to English
     # customContext: "Additional context for the AI" # Optional
@@ -301,8 +304,8 @@ This allows you to manage the plugin configuration alongside your other Jenkins 
 
 ### AWS Bedrock
 - **Models**: `anthropic.claude-3-5-sonnet-20240620-v1:0`, `eu.anthropic.claude-3-5-sonnet-20240620-v1:0` (EU cross-region), `meta.llama3-8b-instruct-v1:0`, `us.amazon.nova-lite-v1:0`, etc.
-- **API Key**: Not required — uses AWS credential chain (instance profiles, environment variables, etc.)
-- **Region**: AWS region (e.g., `us-east-1`, `eu-west-1`). Optional — defaults to AWS SDK region resolution
+- **API Key**: Not required - uses AWS credential chain (instance profiles, environment variables, etc.)
+- **Region**: AWS region (e.g., `us-east-1`, `eu-west-1`). Optional - defaults to AWS SDK region resolution
 - **Endpoint**: Optional Bedrock Runtime endpoint override for VPC endpoints or private AWS-compatible endpoints. Host-only values default to HTTPS
 - **Cross-account role**: Optional IAM role ARN. Jenkins uses its base AWS credentials to call STS AssumeRole, then invokes Bedrock with the temporary credentials
 - **Best for**: Enterprise AWS environments, data residency compliance, using Claude models with AWS infrastructure
@@ -338,7 +341,7 @@ This allows you to manage the plugin configuration alongside your other Jenkins 
 
 ### LangGraph
 - **Models**: The assistant UUID or registered graph name to invoke (e.g. `my-agent`)
-- **API Key**: LangGraph Platform API key — passed as the `x-api-key` header
+- **API Key**: LangGraph Platform API key - passed as the `x-api-key` header
 - **Endpoint**: Base URL of your LangGraph Platform deployment, e.g. `https://your-deployment.langchain.com`
 - **Best for**: Custom LangGraph agents deployed on the LangGraph Platform that expose a `/runs/wait` endpoint
 
@@ -404,13 +407,13 @@ post {
         script {
             // Capture the AI explanation
             def explanation = explainError()
-            
+
             // Use it in notifications
             slackSend(
                 color: 'danger',
                 message: "Build Failed!\n\nAI Analysis:\n${explanation}"
             )
-            
+
             // Or send to email, webhook, etc.
             emailext body: "Error Analysis:\n${explanation}"
         }
@@ -425,7 +428,7 @@ post {
 | **maxLines** | Max log lines to analyze (trims from the end)       | `100`                 |
 | **logPattern** | Regex pattern to filter relevant log lines        | `''` (no filtering)   |
 | **language** | Language for the explanation                        | `'English'`           |
-| **temperature** | Creativity control (0.0–2.0). Leave empty to use the folder or global setting. | Uses folder/global configuration |
+| **temperature** | Creativity control (0.0-2.0). Leave empty to use the folder or global setting. | Uses folder/global configuration |
 | **customContext** | Additional instructions or context for the AI. Overrides global custom context if specified. | Uses global configuration |
 | **collectDownstreamLogs** | Whether to include logs from failed downstream jobs discovered via the `build` step or `Cause.UpstreamCause` | `false` |
 | **downstreamJobPattern** | Regular expression matched against downstream job full names. Used only when downstream collection is enabled. | `''` (collect none) |
@@ -488,9 +491,9 @@ Output appears in the sidebar of the failed job.
 
 ### Auto-Fix: Automatic Pull Request Creation *(Experimental)*
 
-> ⚠️ **Experimental feature.** Auto-fix is opt-in and disabled by default. AI-generated diffs can be incorrect or incomplete — always review the PR before merging. See [docs/auto-fix.md](docs/auto-fix.md) for a full setup guide, supported SCM providers, limitations, and best practices.
+> ⚠️ **Experimental feature.** Auto-fix is opt-in and disabled by default. AI-generated diffs can be incorrect or incomplete - always review the PR before merging. See [docs/auto-fix.md](docs/auto-fix.md) for a full setup guide, supported SCM providers, limitations, and best practices.
 
-When `autoFix: true` is set, the plugin goes one step further than explaining the error — it asks the AI to generate a code fix, commits the changes to a new branch, and opens a pull request for your review.
+When `autoFix: true` is set, the plugin goes one step further than explaining the error - it asks the AI to generate a code fix, commits the changes to a new branch, and opens a pull request for your review.
 
 **Quick start:**
 
@@ -553,11 +556,31 @@ The AI will only propose changes to files matching the glob patterns. Any attemp
 
 Works with Freestyle, Declarative, or any job type.
 
-1. Go to the failed build’s console output
+1. Go to the failed build's console output
 2. Click **Explain Error** button in the top
 3. View results directly under the button
 
 ![AI Error Explanation](docs/images/console-output.png)
+
+### Method 3: Automatic (RunListener)
+
+No pipeline changes needed. When **"Automatically explain failed builds"** is enabled in the global plugin
+configuration, every failed or unstable build is automatically explained by the AI as soon as it completes.
+
+The listener skips builds that already carry an `ErrorExplanationAction` (e.g. from an explicit
+`explainError()` step), so adding the toggle alongside an existing pipeline step produces no
+duplicate explanations.
+
+To enable:
+
+1. Go to `Manage Jenkins` → `Configure System`
+2. Find the **"Explain Error Plugin Configuration"** section
+3. Check **"Automatically explain failed builds"**
+4. Save
+
+All existing configuration (provider, model, language, custom context, quota limits) applies
+to auto-explained builds in the same way as pipeline-step and console-action requests.
+Requests from the RunListener are tracked under the `run_listener` entry point in usage metrics.
 
 ## Troubleshooting
 
@@ -573,10 +596,11 @@ Enable debug logs:
 
 ## Best Practices
 
-1. Use `explainError()` in `post { failure { ... } }` blocks
-2. Apply `logPattern` to focus on relevant errors
-3. Monitor usage metrics and quota outcomes to control costs (see [AI Provider Call Quotas](docs/usage-quota.md))
-4. Keep plugin updated regularly
+1. Use `explainError()` in `post { failure { ... } }` blocks for fine-grained control
+2. Enable **"Automatically explain failed builds"** to cover all jobs without pipeline changes
+3. Apply `logPattern` to focus on relevant errors
+4. Monitor usage metrics and quota outcomes to control costs (see [AI Provider Call Quotas](docs/usage-quota.md))
+5. Keep plugin updated regularly
 
 ## Support & Community
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Whether it’s a compilation error, test failure, or deployment hiccup, this plu
 | **Language** | Language for AI explanations (e.g. `English`, `中文`, `日本語`). Can be overridden at folder and step level. | `English` |
 | **Custom Context** | Additional instructions or context for the AI (e.g., KB article links, organization-specific troubleshooting steps) | *Optional*. Can be overridden at folder and step level. |
 | **Automatically explain failed builds** | When enabled (and AI Error Explanation is active), all failed builds (result `FAILURE`) are automatically explained without any pipeline change. Builds already explained via `explainError()` step are skipped. | Disabled |
+| **Max Log Lines** *(auto-explain)* | Number of console log lines read per build for automatic explanation. Increase this for models with large context windows (e.g. DeepSeek, Kimi). Only visible when **Automatically explain failed builds** is enabled. | `100` |
 
 `Custom Okta AI` adds provider-specific fields for `Okta Token URL`, `Client ID`, `Client Secret`, and optional `Scope`, `API Version`, `App Key`, and custom access-token header settings. This is intended for generic company AI gateways that require an OAuth client-credentials exchange before the chat call.
 
@@ -286,6 +287,7 @@ unclassified:
     # ... your provider configuration above ...
     enableExplanation: true
     # enableAutoExplainOnFailure: true # Optional, automatically explain failed builds without pipeline changes
+    # autoExplainMaxLogLines: 100    # Optional, number of log lines read per build (increase for large-context models)
     # temperature: 0.7 # Optional, leave empty for provider default
     # language: "English" # Optional, defaults to English
     # customContext: "Additional context for the AI" # Optional
@@ -577,7 +579,8 @@ To enable:
 1. Go to `Manage Jenkins` → `Configure System`
 2. Find the **"Explain Error Plugin Configuration"** section
 3. Check **"Automatically explain failed builds"**
-4. Save
+4. Optionally adjust **"Max Log Lines"** — default is `100`. If your model supports a large context window (e.g. DeepSeek, Kimi), increase this to capture more of the build log for a more accurate explanation.
+5. Save
 
 All existing configuration (provider, model, language, custom context, quota limits) applies
 to auto-explained builds in the same way as pipeline-step and console-action requests.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Whether it's a compilation error, test failure, or deployment hiccup, this plugi
 | **Temperature** | Creativity control (0.0-2.0). Leave empty to use the provider default. | *Optional* |
 | **Language** | Language for AI explanations (e.g. `English`, `中文`, `日本語`). Can be overridden at folder and step level. | `English` |
 | **Custom Context** | Additional instructions or context for the AI (e.g., KB article links, organization-specific troubleshooting steps) | *Optional*. Can be overridden at folder and step level. |
-| **Automatically explain failed builds** | When enabled (and AI Error Explanation is active), all failed/unstable builds are automatically explained without any pipeline change. Builds already explained via `explainError()` step are skipped. | Disabled |
+| **Automatically explain failed builds** | When enabled (and AI Error Explanation is active), all failed builds (result `FAILURE`) are automatically explained without any pipeline change. Builds already explained via `explainError()` step are skipped. | Disabled |
 
 `Custom Okta AI` adds provider-specific fields for `Okta Token URL`, `Client ID`, `Client Secret`, and optional `Scope`, `API Version`, `App Key`, and custom access-token header settings. This is intended for generic company AI gateways that require an OAuth client-credentials exchange before the chat call.
 
@@ -565,7 +565,8 @@ Works with Freestyle, Declarative, or any job type.
 ### Method 3: Automatic (RunListener)
 
 No pipeline changes needed. When **"Automatically explain failed builds"** is enabled in the global plugin
-configuration, every failed or unstable build is automatically explained by the AI as soon as it completes.
+configuration, every failed build (result `FAILURE`) is automatically explained by the AI as soon as it completes.
+Unstable, aborted and not-built results are intentionally left untouched.
 
 The listener skips builds that already carry an `ErrorExplanationAction` (e.g. from an explicit
 `explainError()` step), so adding the toggle alongside an existing pipeline step produces no

--- a/docs/usage-quota.md
+++ b/docs/usage-quota.md
@@ -180,4 +180,4 @@ explain_error.provider_calls.my_custom_provider.my-model_v2_0.success
 - **The window resets automatically.** After the time window elapses the counter resets on the next call — you do not need to manually clear it.
 - **Multiple builds running at the same time** share the same counter. Ten concurrent builds all count against the same window.
 - **Console action calls** (clicking the "Explain Error" button) count toward the quota in exactly the same way as `explainError()` pipeline-step calls.
-- **RunListener auto-explain calls** ("Automatically explain failed builds" toggle) also count toward the same quota. If you enable automatic explanation, make sure your quota limits account for the increased call volume from all failing and unstable builds.
+- **RunListener auto-explain calls** ("Automatically explain failed builds" toggle) also count toward the same quota. If you enable automatic explanation, make sure your quota limits account for the increased call volume from all failing builds.

--- a/docs/usage-quota.md
+++ b/docs/usage-quota.md
@@ -148,7 +148,7 @@ The plugin exports the following metric families:
 
 | Metric | Type | Meaning |
 |---|---|---|
-| `explain_error.requests.<entryPoint>.<result>` | Counter | Total requests by entry point (`pipeline_step`, `console_action`) and outcome (`success`, `provider_error`, `quota_rejected`, etc.) |
+| `explain_error.requests.<entryPoint>.<result>` | Counter | Total requests by entry point (`pipeline_step`, `console_action`, `run_listener`) and outcome (`success`, `provider_error`, `quota_rejected`, etc.) |
 | `explain_error.provider_calls.<provider>.<model>.<result>` | Counter | Provider/model-level outcomes for calls that involve a provider (`success`, `cache_hit`, `provider_error`, `quota_rejected`) |
 | `explain_error.request_duration_ms` | Histogram | End-to-end request duration in milliseconds |
 | `explain_error.input_log_lines` | Histogram | Number of input log lines processed per request |
@@ -180,3 +180,4 @@ explain_error.provider_calls.my_custom_provider.my-model_v2_0.success
 - **The window resets automatically.** After the time window elapses the counter resets on the next call — you do not need to manually clear it.
 - **Multiple builds running at the same time** share the same counter. Ten concurrent builds all count against the same window.
 - **Console action calls** (clicking the "Explain Error" button) count toward the quota in exactly the same way as `explainError()` pipeline-step calls.
+- **RunListener auto-explain calls** ("Automatically explain failed builds" toggle) also count toward the same quota. If you enable automatic explanation, make sure your quota limits account for the increased call volume from all failing and unstable builds.

--- a/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
@@ -59,9 +59,9 @@ public class ErrorRunListener extends RunListener<Run<?, ?>> {
             return;
         }
 
-        // Only explain builds that actually failed (UNSTABLE included)
-        Result result = run.getResult();
-        if (result == null || result.isBetterOrEqualTo(Result.SUCCESS)) {
+        // Only explain hard failures. UNSTABLE, ABORTED, NOT_BUILT and SUCCESS
+        // are intentionally left untouched.
+        if (run.getResult() != Result.FAILURE) {
             return;
         }
 

--- a/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
@@ -9,6 +9,7 @@ import hudson.model.listeners.RunListener;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import hudson.util.LogTaskListener;
+import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -72,6 +73,24 @@ public class ErrorRunListener extends RunListener<Run<?, ?>> {
         // Skip if this build was already explained (e.g. via pipeline step)
         if (run.getAction(ErrorExplanationAction.class) != null) {
             LOGGER.fine("[" + fullName(run) + "] Skipping auto-explain: build already has an ErrorExplanationAction.");
+            return;
+        }
+
+        // Verify the provider is valid before printing an optimistic message.
+        // The pipeline step (explainError()) may have already run and failed silently
+        // due to misconfiguration, so we resolve the provider here and check validity.
+        // If the provider is null or invalid, we warn the user and skip — there is no
+        // point saying "AI explanation will appear" when it cannot.
+        ErrorExplainer explainer = new ErrorExplainer();
+        BaseAIProvider provider = explainer.getResolvedProvider(run);
+        if (provider == null) {
+            listener.getLogger().println("[explain-error] Build failed, but no AI provider is configured."
+                    + " No explanation will be generated.");
+            return;
+        }
+        if (provider.isNotValid(new LogTaskListener(LOGGER, Level.FINE), run.getParent(), null)) {
+            listener.getLogger().println("[explain-error] Build failed, but the AI provider configuration is invalid."
+                    + " No explanation will be generated.");
             return;
         }
 

--- a/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
@@ -87,7 +87,8 @@ public class ErrorRunListener extends RunListener<Run<?, ?>> {
             LOGGER.fine("[" + fullName(run) + "] Build failed; automatically requesting AI explanation.");
             TaskListener logListener = new LogTaskListener(LOGGER, Level.FINE);
             ErrorExplainer explainer = new ErrorExplainer();
-            explainer.explainError(run, logListener, "", 100, null, null, false,
+            int maxLogLines = GlobalConfigurationImpl.get().getAutoExplainMaxLogLines();
+            explainer.explainError(run, logListener, "", maxLogLines, null, null, false,
                     null, authentication, null, UsageEvent.EntryPoint.RUN_LISTENER);
             // The build has already been finalized and saved by the time this
             // background task runs, so persist any freshly added action ourselves.

--- a/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
@@ -8,6 +8,7 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import hudson.util.LogTaskListener;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -23,9 +24,13 @@ import org.springframework.security.core.Authentication;
  * avoid duplicate explanations when the pipeline already calls
  * {@code explainError()} explicitly.
  *
- * The AI provider call runs on a dedicated background thread so it never blocks
- * the build completion / executor-release flow. All exceptions are safely caught
- * and logged so they never interrupt the normal build lifecycle.
+ * A single summary line ("[explain-error] Build failed. Auto-explain triggered...")
+ * is written to the build console synchronously in {@link #onCompleted} while
+ * the stream is guaranteed open. The actual AI provider call runs on a dedicated
+ * background thread with a {@link LogTaskListener}, so the verbose setup messages
+ * from {@link ErrorExplainer#explainError} go to the plugin log rather than
+ * cluttering the build console. All exceptions are safely caught and logged so
+ * they never interrupt the normal build lifecycle.
  */
 @Extension
 public class ErrorRunListener extends RunListener<Run<?, ?>> {
@@ -70,25 +75,34 @@ public class ErrorRunListener extends RunListener<Run<?, ?>> {
             return;
         }
 
+        // Write a single summary line while the stream is guaranteed open.
+        // The background thread writes no further console output; verbose
+        // setup messages from ErrorExplainer go to the plugin log instead.
+        listener.getLogger().println("[explain-error] Build failed. Auto-explain triggered"
+                + " \u2014 AI explanation will appear on the build page shortly.");
+
         // Capture the security context on the build thread; the background thread
         // starts with no authentication of its own.
         Authentication authentication = Jenkins.getAuthentication2();
-        EXECUTOR.submit(() -> explainAsync(run, listener, authentication));
+        EXECUTOR.submit(() -> explainAsync(run, authentication));
     }
 
     /**
-     * Performs the AI explanation off the build thread. The {@code listener} is the
-     * build's original TaskListener passed from {@link #onCompleted}; pre-AI messages
-     * (provider resolution, log extraction, etc.) are written to it while the stream
-     * is still open. Post-AI messages may arrive after Jenkins has closed the stream
-     * and will be silently dropped by the underlying PrintStream.
+     * Performs the AI explanation off the build thread. Uses a
+     * {@link LogTaskListener} instead of the build's original
+     * {@link TaskListener} so the verbose diagnostic messages from
+     * {@link ErrorExplainer#explainError} (provider resolution, log extraction,
+     * etc.) are written to the plugin log rather than the build console.
+     * A single summary line was already written synchronously in
+     * {@link #onCompleted} where the stream was guaranteed open.
      */
-    private void explainAsync(Run<?, ?> run, TaskListener listener, Authentication authentication) {
+    private void explainAsync(Run<?, ?> run, Authentication authentication) {
         try (ACLContext ignored = ACL.as2(authentication)) {
             LOGGER.fine("[" + fullName(run) + "] Build failed; automatically requesting AI explanation.");
             ErrorExplainer explainer = new ErrorExplainer();
             int maxLogLines = GlobalConfigurationImpl.get().getAutoExplainMaxLogLines();
-            explainer.explainError(run, listener, "", maxLogLines, null, null, false,
+            explainer.explainError(run, new LogTaskListener(LOGGER, Level.FINE),
+                    "", maxLogLines, null, null, false,
                     null, authentication, null, UsageEvent.EntryPoint.RUN_LISTENER);
             // The build has already been finalized and saved by the time this
             // background task runs, so persist any freshly added action ourselves.

--- a/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
@@ -1,0 +1,77 @@
+package io.jenkins.plugins.explain_error;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import hudson.util.LogTaskListener;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+
+/**
+ * {@link RunListener} that automatically triggers AI error explanation
+ * when a build fails and the global "auto explain on failure" toggle is enabled.
+ *
+ * Builds that already carry an {@link ErrorExplanationAction} are skipped to
+ * avoid duplicate explanations when the pipeline already calls
+ * {@code explainError()} explicitly.
+ *
+ * All exceptions are safely caught and logged so they never interrupt the
+ * normal build completion flow.
+ */
+@Extension
+public class ErrorRunListener extends RunListener<Run<?, ?>> {
+
+    private static final Logger LOGGER = Logger.getLogger(ErrorRunListener.class.getName());
+
+    @SuppressWarnings("rawtypes")
+    public ErrorRunListener() {
+        super((Class) Run.class);
+    }
+
+    @Override
+    public void onCompleted(Run<?, ?> run, @NonNull TaskListener listener) {
+        try {
+            GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+
+            if (!config.isEnableAutoExplainOnFailure()) {
+                return;
+            }
+
+            // Only explain builds that actually failed (UNSTABLE included)
+            Result result = run.getResult();
+            if (result == null || result.isBetterOrEqualTo(Result.SUCCESS)) {
+                return;
+            }
+
+            // Skip if this build was already explained (e.g. via pipeline step)
+            if (run.getAction(ErrorExplanationAction.class) != null) {
+                LOGGER.fine("[" + fullName(run) + "] Skipping auto-explain: build already has an ErrorExplanationAction.");
+                return;
+            }
+
+            // Use a LogTaskListener in case the original listener is no longer
+            // suitable for long-running tasks; we also piggyback on the original
+            // listener for best-effort console output
+            TaskListener logListener = listener != null ? listener : new LogTaskListener(LOGGER, Level.INFO);
+
+            logListener.getLogger().println("[explain-error] Build failed — automatically requesting AI explanation.");
+
+            ErrorExplainer explainer = new ErrorExplainer();
+            explainer.explainError(run, logListener, "", 100, null, null, false,
+                    null, Jenkins.getAuthentication2(), null, UsageEvent.EntryPoint.RUN_LISTENER);
+
+        } catch (Exception e) {
+            // Safety net: never let a failure in the listener surface to the
+            // build completion pipeline. Log and move on.
+            LOGGER.log(Level.WARNING, "[" + fullName(run) + "] Auto-explain on failure failed unexpectedly.", e);
+        }
+    }
+
+    private static String fullName(Run<?, ?> run) {
+        return run.getParent().getFullName() + " #" + run.getNumber();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
@@ -8,7 +8,6 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
-import hudson.util.LogTaskListener;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -74,21 +73,22 @@ public class ErrorRunListener extends RunListener<Run<?, ?>> {
         // Capture the security context on the build thread; the background thread
         // starts with no authentication of its own.
         Authentication authentication = Jenkins.getAuthentication2();
-        EXECUTOR.submit(() -> explainAsync(run, authentication));
+        EXECUTOR.submit(() -> explainAsync(run, listener, authentication));
     }
 
     /**
-     * Performs the AI explanation off the build thread. The build console log is
-     * already being finalized by the time this runs, so output is sent to the
-     * Jenkins system log rather than the build's listener.
+     * Performs the AI explanation off the build thread. The {@code listener} is the
+     * build's original TaskListener passed from {@link #onCompleted}; pre-AI messages
+     * (provider resolution, log extraction, etc.) are written to it while the stream
+     * is still open. Post-AI messages may arrive after Jenkins has closed the stream
+     * and will be silently dropped by the underlying PrintStream.
      */
-    private void explainAsync(Run<?, ?> run, Authentication authentication) {
+    private void explainAsync(Run<?, ?> run, TaskListener listener, Authentication authentication) {
         try (ACLContext ignored = ACL.as2(authentication)) {
             LOGGER.fine("[" + fullName(run) + "] Build failed; automatically requesting AI explanation.");
-            TaskListener logListener = new LogTaskListener(LOGGER, Level.FINE);
             ErrorExplainer explainer = new ErrorExplainer();
             int maxLogLines = GlobalConfigurationImpl.get().getAutoExplainMaxLogLines();
-            explainer.explainError(run, logListener, "", maxLogLines, null, null, false,
+            explainer.explainError(run, listener, "", maxLogLines, null, null, false,
                     null, authentication, null, UsageEvent.EntryPoint.RUN_LISTENER);
             // The build has already been finalized and saved by the time this
             // background task runs, so persist any freshly added action ourselves.

--- a/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ErrorRunListener.java
@@ -6,10 +6,15 @@ import hudson.model.Run;
 import hudson.model.Result;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.util.LogTaskListener;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
+import org.springframework.security.core.Authentication;
 
 /**
  * {@link RunListener} that automatically triggers AI error explanation
@@ -19,13 +24,27 @@ import jenkins.model.Jenkins;
  * avoid duplicate explanations when the pipeline already calls
  * {@code explainError()} explicitly.
  *
- * All exceptions are safely caught and logged so they never interrupt the
- * normal build completion flow.
+ * The AI provider call runs on a dedicated background thread so it never blocks
+ * the build completion / executor-release flow. All exceptions are safely caught
+ * and logged so they never interrupt the normal build lifecycle.
  */
 @Extension
 public class ErrorRunListener extends RunListener<Run<?, ?>> {
 
     private static final Logger LOGGER = Logger.getLogger(ErrorRunListener.class.getName());
+
+    /**
+     * Dedicated daemon thread pool for auto-explain work. {@code onCompleted} runs
+     * on the build's own thread, so making the (potentially slow) AI provider call
+     * inline would hold the executor until the provider responds. Offloading keeps
+     * the build completion flow non-blocking. Daemon threads do not prevent JVM
+     * shutdown and avoid polluting {@code ForkJoinPool.commonPool()}.
+     */
+    private static final ExecutorService EXECUTOR = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r, "explain-error-run-listener");
+        t.setDaemon(true);
+        return t;
+    });
 
     @SuppressWarnings("rawtypes")
     public ErrorRunListener() {
@@ -34,36 +53,45 @@ public class ErrorRunListener extends RunListener<Run<?, ?>> {
 
     @Override
     public void onCompleted(Run<?, ?> run, @NonNull TaskListener listener) {
-        try {
-            GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
 
-            if (!config.isEnableAutoExplainOnFailure()) {
-                return;
-            }
+        if (!config.isEnableAutoExplainOnFailure()) {
+            return;
+        }
 
-            // Only explain builds that actually failed (UNSTABLE included)
-            Result result = run.getResult();
-            if (result == null || result.isBetterOrEqualTo(Result.SUCCESS)) {
-                return;
-            }
+        // Only explain builds that actually failed (UNSTABLE included)
+        Result result = run.getResult();
+        if (result == null || result.isBetterOrEqualTo(Result.SUCCESS)) {
+            return;
+        }
 
-            // Skip if this build was already explained (e.g. via pipeline step)
-            if (run.getAction(ErrorExplanationAction.class) != null) {
-                LOGGER.fine("[" + fullName(run) + "] Skipping auto-explain: build already has an ErrorExplanationAction.");
-                return;
-            }
+        // Skip if this build was already explained (e.g. via pipeline step)
+        if (run.getAction(ErrorExplanationAction.class) != null) {
+            LOGGER.fine("[" + fullName(run) + "] Skipping auto-explain: build already has an ErrorExplanationAction.");
+            return;
+        }
 
-            // Use a LogTaskListener in case the original listener is no longer
-            // suitable for long-running tasks; we also piggyback on the original
-            // listener for best-effort console output
-            TaskListener logListener = listener != null ? listener : new LogTaskListener(LOGGER, Level.INFO);
+        // Capture the security context on the build thread; the background thread
+        // starts with no authentication of its own.
+        Authentication authentication = Jenkins.getAuthentication2();
+        EXECUTOR.submit(() -> explainAsync(run, authentication));
+    }
 
-            logListener.getLogger().println("[explain-error] Build failed — automatically requesting AI explanation.");
-
+    /**
+     * Performs the AI explanation off the build thread. The build console log is
+     * already being finalized by the time this runs, so output is sent to the
+     * Jenkins system log rather than the build's listener.
+     */
+    private void explainAsync(Run<?, ?> run, Authentication authentication) {
+        try (ACLContext ignored = ACL.as2(authentication)) {
+            LOGGER.fine("[" + fullName(run) + "] Build failed; automatically requesting AI explanation.");
+            TaskListener logListener = new LogTaskListener(LOGGER, Level.FINE);
             ErrorExplainer explainer = new ErrorExplainer();
             explainer.explainError(run, logListener, "", 100, null, null, false,
-                    null, Jenkins.getAuthentication2(), null, UsageEvent.EntryPoint.RUN_LISTENER);
-
+                    null, authentication, null, UsageEvent.EntryPoint.RUN_LISTENER);
+            // The build has already been finalized and saved by the time this
+            // background task runs, so persist any freshly added action ourselves.
+            run.save();
         } catch (Exception e) {
             // Safety net: never let a failure in the listener surface to the
             // build completion pipeline. Log and move on.

--- a/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
@@ -40,6 +40,7 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
     private int maxProviderCallsPerWindow = 100;
 
     private boolean enableAutoExplainOnFailure = false;
+    private int autoExplainMaxLogLines = 100;
 
     private transient QuotaEnforcer quotaEnforcer;
 
@@ -149,6 +150,15 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
     @DataBoundSetter
     public void setEnableAutoExplainOnFailure(boolean enableAutoExplainOnFailure) {
         this.enableAutoExplainOnFailure = enableAutoExplainOnFailure;
+    }
+
+    public int getAutoExplainMaxLogLines() {
+        return autoExplainMaxLogLines;
+    }
+
+    @DataBoundSetter
+    public void setAutoExplainMaxLogLines(int autoExplainMaxLogLines) {
+        this.autoExplainMaxLogLines = Math.max(1, autoExplainMaxLogLines);
     }
 
     public String getCustomContext() {

--- a/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/GlobalConfigurationImpl.java
@@ -39,6 +39,8 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
     private QuotaWindow quotaWindow = QuotaWindow.HOURLY;
     private int maxProviderCallsPerWindow = 100;
 
+    private boolean enableAutoExplainOnFailure = false;
+
     private transient QuotaEnforcer quotaEnforcer;
 
     public GlobalConfigurationImpl() {
@@ -138,6 +140,15 @@ public class GlobalConfigurationImpl extends GlobalConfiguration {
     @DataBoundSetter
     public void setEnableExplanation(boolean enableExplanation) {
         this.enableExplanation = enableExplanation;
+    }
+
+    public boolean isEnableAutoExplainOnFailure() {
+        return enableAutoExplainOnFailure;
+    }
+
+    @DataBoundSetter
+    public void setEnableAutoExplainOnFailure(boolean enableAutoExplainOnFailure) {
+        this.enableAutoExplainOnFailure = enableAutoExplainOnFailure;
     }
 
     public String getCustomContext() {

--- a/src/main/java/io/jenkins/plugins/explain_error/UsageEvent.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/UsageEvent.java
@@ -26,7 +26,8 @@ public record UsageEvent(
 
     public enum EntryPoint {
         PIPELINE_STEP("pipeline_step"),
-        CONSOLE_ACTION("console_action");
+        CONSOLE_ACTION("console_action"),
+        RUN_LISTENER("run_listener");
 
         private final String value;
 

--- a/src/main/resources/io/jenkins/plugins/explain_error/GlobalConfigurationImpl/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/GlobalConfigurationImpl/config.jelly
@@ -26,11 +26,14 @@
             <f:number clazz="setting-input" min="0" />
           </f:entry>
         </f:optionalBlock>
-        <f:entry title="" field="enableAutoExplainOnFailure">
-          <f:checkbox title="Automatically explain failed builds"
-                      default="false"
-                      description="When enabled, all failed builds will automatically trigger AI explanation. Requires 'Enable AI Error Explanation' to be active. Builds already explained via explainError() step are skipped." />
-        </f:entry>
+        <f:optionalBlock field="enableAutoExplainOnFailure" title="Automatically explain failed builds"
+                         checked="${it.enableAutoExplainOnFailure}" inline="true"
+                         help="When enabled, all failed builds will automatically trigger AI explanation. Requires 'Enable AI Error Explanation' to be active. Builds already explained via explainError() step are skipped.">
+          <f:entry title="Max Log Lines" field="autoExplainMaxLogLines"
+                   description="Number of log lines to read from the build console for auto-explanation. Increase this for models with larger context windows (e.g. DeepSeek, Kimi).">
+            <f:number clazz="setting-input" min="1" default="100" />
+          </f:entry>
+        </f:optionalBlock>
       </f:optionalBlock>
     </f:section>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/explain_error/GlobalConfigurationImpl/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/GlobalConfigurationImpl/config.jelly
@@ -26,6 +26,11 @@
             <f:number clazz="setting-input" min="0" />
           </f:entry>
         </f:optionalBlock>
+        <f:entry title="" field="enableAutoExplainOnFailure">
+          <f:checkbox title="Automatically explain failed builds"
+                      default="false"
+                      description="When enabled, all failed builds will automatically trigger AI explanation. Requires 'Enable AI Error Explanation' to be active. Builds already explained via explainError() step are skipped." />
+        </f:entry>
       </f:optionalBlock>
     </f:section>
 </j:jelly>

--- a/src/test/java/io/jenkins/plugins/explain_error/ErrorRunListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ErrorRunListenerTest.java
@@ -90,13 +90,20 @@ class ErrorRunListenerTest {
     }
 
     @Test
-    void unstableBuildAlsoTriggersAutoExplain(JenkinsRule jenkins) throws Exception {
-        // Verify that UNSTABLE result is worse than SUCCESS,
-        // which means it passes the gate in ErrorRunListener.onCompleted
-        assertFalse(Result.UNSTABLE.isBetterOrEqualTo(Result.SUCCESS),
-                "UNSTABLE should NOT be better-or-equal to SUCCESS");
-        assertTrue(Result.SUCCESS.isBetterOrEqualTo(Result.SUCCESS));
-        assertFalse(Result.FAILURE.isBetterOrEqualTo(Result.SUCCESS));
+    void unstableBuildIsNotAutoExplained(JenkinsRule jenkins) throws Exception {
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        TestProvider provider = new TestProvider();
+        config.setEnableExplanation(true);
+        config.setAiProvider(provider);
+        config.setEnableAutoExplainOnFailure(true);
+
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        project.getBuildersList().add(new org.jvnet.hudson.test.UnstableBuilder());
+        FreeStyleBuild build = (FreeStyleBuild) jenkins.assertBuildStatus(
+                Result.UNSTABLE, project.scheduleBuild2(0).get());
+
+        // Auto-explain is restricted to result == FAILURE; UNSTABLE must be ignored.
+        assertStaysUnexplained(build);
     }
 
     @Test
@@ -152,5 +159,18 @@ class ErrorRunListenerTest {
             Thread.sleep(100);
         }
         return build.getAction(ErrorExplanationAction.class);
+    }
+
+    /**
+     * Asserts that no explanation action ever appears. Polls for a short window
+     * so a regression that wrongly dispatched the async explanation would be
+     * caught rather than racing past an immediate assertion.
+     */
+    private static void assertStaysUnexplained(FreeStyleBuild build) throws InterruptedException {
+        for (int i = 0; i < 20; i++) {
+            assertNull(build.getAction(ErrorExplanationAction.class),
+                    "Build should NOT be auto-explained");
+            Thread.sleep(50);
+        }
     }
 }

--- a/src/test/java/io/jenkins/plugins/explain_error/ErrorRunListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ErrorRunListenerTest.java
@@ -1,0 +1,140 @@
+package io.jenkins.plugins.explain_error;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import io.jenkins.plugins.explain_error.provider.TestProvider;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Tests for {@link ErrorRunListener}.
+ */
+@WithJenkins
+class ErrorRunListenerTest {
+
+    @Test
+    void autoExplainOnFailureIsDisabledByDefault(JenkinsRule jenkins) throws Exception {
+        GlobalConfigurationImpl freshConfig = GlobalConfigurationImpl.get();
+        assertFalse(freshConfig.isEnableAutoExplainOnFailure(),
+                "Auto-explain on failure must be disabled by default");
+    }
+
+    @Test
+    void successfulBuildDoesNotAddExplanationAction(JenkinsRule jenkins) throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+
+        assertNull(build.getAction(ErrorExplanationAction.class),
+                "Successful build should not have an ErrorExplanationAction");
+    }
+
+    @Test
+    void failedBuildAddsExplanationAction(JenkinsRule jenkins) throws Exception {
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        TestProvider provider = new TestProvider();
+        provider.setProviderName("AutoExplain-Provider");
+        config.setEnableExplanation(true);
+        config.setAiProvider(provider);
+        config.setEnableAutoExplainOnFailure(true);
+
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        project.getBuildersList().add(new hudson.tasks.Shell("exit 1"));
+        FreeStyleBuild build = (FreeStyleBuild) jenkins.assertBuildStatus(
+                Result.FAILURE, project.scheduleBuild2(0).get());
+
+        assertNotNull(build.getAction(ErrorExplanationAction.class),
+                "Failed build should have an ErrorExplanationAction");
+    }
+
+    @Test
+    void failedBuildThatAlreadyHasActionIsSkipped(JenkinsRule jenkins) throws Exception {
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        TestProvider provider = new TestProvider();
+        provider.setProviderName("AutoExplain-Provider");
+        config.setEnableExplanation(true);
+        config.setAiProvider(provider);
+        config.setEnableAutoExplainOnFailure(true);
+
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        project.getBuildersList().add(new hudson.tasks.Shell("exit 1"));
+        FreeStyleBuild build = (FreeStyleBuild) jenkins.assertBuildStatus(
+                Result.FAILURE, project.scheduleBuild2(0).get());
+
+        // The RunListener should have added exactly one action.
+        // If the listener added a second one (not detecting the first),
+        // we'd see more than one.
+        assertEquals(1, build.getActions(ErrorExplanationAction.class).size(),
+                "Listener must detect existing action and skip");
+    }
+
+    @Test
+    void disabledAutoExplainDoesNotAddAction(JenkinsRule jenkins) throws Exception {
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        TestProvider provider = new TestProvider();
+        config.setEnableExplanation(true);
+        config.setAiProvider(provider);
+        config.setEnableAutoExplainOnFailure(false);
+
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        project.getBuildersList().add(new hudson.tasks.Shell("exit 1"));
+        FreeStyleBuild build = (FreeStyleBuild) jenkins.assertBuildStatus(
+                Result.FAILURE, project.scheduleBuild2(0).get());
+
+        assertNull(build.getAction(ErrorExplanationAction.class),
+                "Failed build should NOT have an ErrorExplanationAction when auto-explain is disabled");
+    }
+
+    @Test
+    void unstableBuildAlsoTriggersAutoExplain(JenkinsRule jenkins) throws Exception {
+        // Verify that UNSTABLE result is worse than SUCCESS,
+        // which means it passes the gate in ErrorRunListener.onCompleted
+        assertFalse(Result.UNSTABLE.isBetterOrEqualTo(Result.SUCCESS),
+                "UNSTABLE should NOT be better-or-equal to SUCCESS");
+        assertTrue(Result.SUCCESS.isBetterOrEqualTo(Result.SUCCESS));
+        assertFalse(Result.FAILURE.isBetterOrEqualTo(Result.SUCCESS));
+    }
+
+    @Test
+    void exceptionInListenerDoesNotBreakBuild(JenkinsRule jenkins) throws Exception {
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        TestProvider failingProvider = new TestProvider();
+        failingProvider.setThrowError(true);
+        config.setAiProvider(failingProvider);
+        config.setEnableAutoExplainOnFailure(true);
+
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        project.getBuildersList().add(new hudson.tasks.Shell("exit 1"));
+        FreeStyleBuild build = (FreeStyleBuild) jenkins.assertBuildStatus(
+                Result.FAILURE, project.scheduleBuild2(0).get());
+
+        assertNotNull(build);
+        assertEquals(Result.FAILURE, build.getResult());
+        // No action because the provider threw; the listener catches internally
+        assertNull(build.getAction(ErrorExplanationAction.class),
+                "No action should be present when provider throws");
+    }
+
+    @Test
+    void autoExplainUsesConfiguredProvider(JenkinsRule jenkins) throws Exception {
+        GlobalConfigurationImpl config = GlobalConfigurationImpl.get();
+        TestProvider provider = new TestProvider();
+        provider.setProviderName("Custom-Provider");
+        config.setEnableExplanation(true);
+        config.setAiProvider(provider);
+        config.setEnableAutoExplainOnFailure(true);
+
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        project.getBuildersList().add(new hudson.tasks.Shell("exit 1"));
+        FreeStyleBuild build = (FreeStyleBuild) jenkins.assertBuildStatus(
+                Result.FAILURE, project.scheduleBuild2(0).get());
+
+        ErrorExplanationAction action = build.getAction(ErrorExplanationAction.class);
+        assertNotNull(action);
+        assertTrue(action.hasValidExplanation(), "Explanation should be valid");
+        assertEquals("Custom-Provider", action.getProviderName());
+    }
+}

--- a/src/test/java/io/jenkins/plugins/explain_error/ErrorRunListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ErrorRunListenerTest.java
@@ -46,7 +46,7 @@ class ErrorRunListenerTest {
         FreeStyleBuild build = (FreeStyleBuild) jenkins.assertBuildStatus(
                 Result.FAILURE, project.scheduleBuild2(0).get());
 
-        assertNotNull(build.getAction(ErrorExplanationAction.class),
+        assertNotNull(awaitExplanation(build),
                 "Failed build should have an ErrorExplanationAction");
     }
 
@@ -64,9 +64,10 @@ class ErrorRunListenerTest {
         FreeStyleBuild build = (FreeStyleBuild) jenkins.assertBuildStatus(
                 Result.FAILURE, project.scheduleBuild2(0).get());
 
-        // The RunListener should have added exactly one action.
-        // If the listener added a second one (not detecting the first),
+        // Wait for the asynchronous listener to add its action, then verify it
+        // added exactly one. If it added a second (not detecting the first),
         // we'd see more than one.
+        assertNotNull(awaitExplanation(build));
         assertEquals(1, build.getActions(ErrorExplanationAction.class).size(),
                 "Listener must detect existing action and skip");
     }
@@ -132,9 +133,24 @@ class ErrorRunListenerTest {
         FreeStyleBuild build = (FreeStyleBuild) jenkins.assertBuildStatus(
                 Result.FAILURE, project.scheduleBuild2(0).get());
 
-        ErrorExplanationAction action = build.getAction(ErrorExplanationAction.class);
+        ErrorExplanationAction action = awaitExplanation(build);
         assertNotNull(action);
         assertTrue(action.hasValidExplanation(), "Explanation should be valid");
         assertEquals("Custom-Provider", action.getProviderName());
+    }
+
+    /**
+     * The explanation is produced on a background thread, so poll for the action
+     * to appear instead of asserting on it immediately.
+     */
+    private static ErrorExplanationAction awaitExplanation(FreeStyleBuild build) throws InterruptedException {
+        for (int i = 0; i < 100; i++) {
+            ErrorExplanationAction action = build.getAction(ErrorExplanationAction.class);
+            if (action != null) {
+                return action;
+            }
+            Thread.sleep(100);
+        }
+        return build.getAction(ErrorExplanationAction.class);
     }
 }


### PR DESCRIPTION
## Summary

Adds a `RunListener` extension that automatically triggers AI error explanation when a build fails, controlled by a new admin toggle in global configuration.

Related: #202