### PR TITLE
fix: use Item.CONFIGURE instead of Jenkins.ADMINISTER for folder-level permission checks

### DIFF
--- a/src/main/java/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/ExplainErrorFolderProperty.java
@@ -5,6 +5,7 @@ import com.cloudbees.hudson.plugins.folder.AbstractFolderProperty;
 import com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Item;
 import hudson.Extension;
 import hudson.model.ItemGroup;
 import hudson.util.FormValidation;
@@ -12,6 +13,7 @@ import hudson.util.ListBoxModel;
 import io.jenkins.plugins.explain_error.provider.BaseAIProvider;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -325,8 +327,8 @@ public class ExplainErrorFolderProperty extends AbstractFolderProperty<AbstractF
         }
 
         @POST
-        public ListBoxModel doFillQuotaWindowItems() {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        public ListBoxModel doFillQuotaWindowItems(@AncestorInPath AbstractFolder<?> folder) {
+            folder.checkPermission(Item.CONFIGURE);
             ListBoxModel items = new ListBoxModel();
             for (QuotaWindow value : QuotaWindow.values()) {
                 items.add(value.getDisplayName(), value.name());
@@ -335,8 +337,9 @@ public class ExplainErrorFolderProperty extends AbstractFolderProperty<AbstractF
         }
 
         @POST
-        public FormValidation doCheckMaxProviderCallsPerWindow(@QueryParameter int value) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        public FormValidation doCheckMaxProviderCallsPerWindow(@AncestorInPath AbstractFolder<?> folder,
+                                                               @QueryParameter int value) {
+            folder.checkPermission(Item.CONFIGURE);
             if (value < 0) {
                 return FormValidation.error("Max provider calls per window must be 0 or greater.");
             }

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/AnthropicProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/AnthropicProvider.java
@@ -21,6 +21,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.GET;
@@ -259,12 +260,13 @@ public class AnthropicProvider extends BaseAIProvider {
          * This is called when the "Test Configuration" button is clicked.
          */
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("apiKey") Secret apiKey,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("apiKey") Secret apiKey,
                                                   @QueryParameter("credentialsId") String credentialsId,
                                                   @QueryParameter("url") String url,
                                                   @QueryParameter("model") String model,
                                                   @QueryParameter("maxTokens") Integer maxTokens) throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             AnthropicProvider provider = new AnthropicProvider(url, model, apiKey, credentialsId, maxTokens);
             try {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
@@ -32,6 +32,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
@@ -694,13 +695,14 @@ public class AzureOpenAIProvider extends BaseAIProvider {
         }
 
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("endpoint") String endpoint,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("endpoint") String endpoint,
                                                   @QueryParameter("deployment") String deployment,
                                                   @QueryParameter("apiVersion") String apiVersion,
                                                   @QueryParameter("credentialsId") String credentialsId,
                                                   @QueryParameter("apiType") String apiType)
                 throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             ApiType selectedApiType;
             try {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/BaseAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/BaseAIProvider.java
@@ -23,6 +23,7 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.model.TaskListener;
+import hudson.security.AccessControlled;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.explain_error.ExplanationException;
 import io.jenkins.plugins.explain_error.JenkinsLogAnalysis;
@@ -291,6 +292,21 @@ public abstract class BaseAIProvider extends AbstractDescribableImpl<BaseAIProvi
 
     public abstract static class BaseProviderDescriptor extends Descriptor<BaseAIProvider> {
         public abstract String getDefaultModel();
+
+        /**
+         * Check that the user has permission to configure the plugin.
+         * When called from an item context (folder, job), checks {@link Item#CONFIGURE}.
+         * When called from a global context, checks {@link Jenkins#ADMINISTER}.
+         *
+         * @param context the access-controlled context, or {@code null} for global context
+         */
+        protected static void checkConfigurePermission(@CheckForNull AccessControlled context) {
+            if (context instanceof Item item) {
+                item.checkPermission(Item.CONFIGURE);
+            } else {
+                Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            }
+        }
 
         @POST
         @SuppressWarnings("lgtm[jenkins/no-permission-check]")

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/BedrockProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/BedrockProvider.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ProxyConfiguration;
 import hudson.Util;
+import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
@@ -25,6 +26,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.variant.OptionalExtension;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
@@ -267,12 +269,13 @@ public class BedrockProvider extends BaseAIProvider {
          * This is called when the "Test Configuration" button is clicked.
          */
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("url") String url,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("url") String url,
                                                   @QueryParameter("model") String model,
                                                   @QueryParameter("region") String region,
                                                   @QueryParameter("roleArn") String roleArn)
                 throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             BedrockProvider provider = new BedrockProvider(url, model, region, roleArn);
             try {
@@ -285,16 +288,14 @@ public class BedrockProvider extends BaseAIProvider {
 
         @POST
         @Override
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         public FormValidation doCheckUrl(@QueryParameter String value) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-
             return validateEndpoint(value);
         }
 
         @POST
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         public FormValidation doCheckRoleArn(@QueryParameter String value) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-
             String roleArn = Util.fixEmptyAndTrim(value);
             if (roleArn == null) {
                 return FormValidation.ok();

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/CustomOktaAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/CustomOktaAIProvider.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
@@ -28,6 +29,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -567,9 +569,8 @@ public class CustomOktaAIProvider extends BaseAIProvider {
         }
 
         @POST
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         public FormValidation doCheckTimeoutSeconds(@QueryParameter Integer value) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-
             if (value == null) {
                 return FormValidation.ok();
             }
@@ -583,7 +584,8 @@ public class CustomOktaAIProvider extends BaseAIProvider {
         }
 
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("url") String url,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("url") String url,
                                                   @QueryParameter("tokenUrl") String tokenUrl,
                                                   @QueryParameter("model") String model,
                                                   @QueryParameter("clientId") String clientId,
@@ -596,7 +598,7 @@ public class CustomOktaAIProvider extends BaseAIProvider {
                                                   @QueryParameter("userId") String userId,
                                                   @QueryParameter("timeoutSeconds") Integer timeoutSeconds)
                 throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             CustomOktaAIProvider provider = new CustomOktaAIProvider(url, tokenUrl, model, clientId, clientSecret);
             provider.setScope(scope);

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/DeepSeekProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/DeepSeekProvider.java
@@ -9,6 +9,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AutoCompletionCandidates;
+import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
@@ -17,6 +18,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.GET;
@@ -130,10 +132,11 @@ public class DeepSeekProvider extends BaseAIProvider {
         }
 
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("apiKey") Secret apiKey,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("apiKey") Secret apiKey,
                                                   @QueryParameter("url") String url,
                                                   @QueryParameter("model") String model) throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             DeepSeekProvider provider = new DeepSeekProvider(url, model, apiKey);
             try {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/GeminiProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/GeminiProvider.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
@@ -16,6 +17,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
@@ -99,10 +101,11 @@ public class GeminiProvider extends BaseAIProvider {
          * This is called when the "Test Configuration" button is clicked.
          */
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("apiKey") Secret apiKey,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("apiKey") Secret apiKey,
                                                   @QueryParameter("url") String url,
                                                   @QueryParameter("model") String model) throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             GeminiProvider provider = new GeminiProvider(url, model, apiKey);
             try {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/LangGraphProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/LangGraphProvider.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -352,10 +354,11 @@ public class LangGraphProvider extends BaseAIProvider {
         }
 
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("apiKey") Secret apiKey,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("apiKey") Secret apiKey,
                                                   @QueryParameter("url") String url,
                                                   @QueryParameter("model") String model) throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             LangGraphProvider provider = new LangGraphProvider(url, model, apiKey);
             try {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/MicrosoftFoundryProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/MicrosoftFoundryProvider.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
@@ -16,6 +17,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
@@ -126,8 +128,8 @@ public class MicrosoftFoundryProvider extends BaseAIProvider {
 
         @POST
         @Override
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         public FormValidation doCheckUrl(@QueryParameter String value) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             if (value == null || value.isBlank()) {
                 return FormValidation.error("Endpoint is required.");
             }
@@ -135,8 +137,8 @@ public class MicrosoftFoundryProvider extends BaseAIProvider {
         }
 
         @POST
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         public FormValidation doCheckModel(@QueryParameter String value) {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             if (value == null || value.isBlank()) {
                 return FormValidation.error("Model deployment is required.");
             }
@@ -144,10 +146,11 @@ public class MicrosoftFoundryProvider extends BaseAIProvider {
         }
 
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("apiKey") Secret apiKey,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("apiKey") Secret apiKey,
                                                   @QueryParameter("url") String url,
                                                   @QueryParameter("model") String model) throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             MicrosoftFoundryProvider provider = new MicrosoftFoundryProvider(url, model, apiKey);
             try {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/OllamaProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/OllamaProvider.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.explain_error.ExplanationException;
@@ -16,6 +17,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
@@ -102,9 +104,10 @@ public class OllamaProvider extends BaseAIProvider {
          * This is called when the "Test Configuration" button is clicked.
          */
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("url") String url,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("url") String url,
                                                   @QueryParameter("model") String model) throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             OllamaProvider provider = new OllamaProvider(url, model);
             try {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAIProvider.java
@@ -11,12 +11,14 @@ import hudson.Util;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
+import hudson.model.Item;
 import hudson.util.Secret;
 import io.jenkins.plugins.explain_error.ExplanationException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.GET;
@@ -128,10 +130,11 @@ public class OpenAIProvider extends BaseAIProvider {
          * This is called when the "Test Configuration" button is clicked.
          */
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("apiKey") Secret apiKey,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("apiKey") Secret apiKey,
                                                   @QueryParameter("url") String url,
                                                   @QueryParameter("model") String model) throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             OpenAIProvider provider = new OpenAIProvider(url, model, apiKey);
             try {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/QwenProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/QwenProvider.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.GET;
@@ -224,11 +225,12 @@ public class QwenProvider extends BaseAIProvider {
         }
 
         @POST
-        public FormValidation doTestConfiguration(@QueryParameter("apiKey") Secret apiKey,
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("apiKey") Secret apiKey,
                                                   @QueryParameter("credentialsId") String credentialsId,
                                                   @QueryParameter("url") String url,
                                                   @QueryParameter("model") String model) throws ExplanationException {
-            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            checkConfigurePermission(context);
 
             QwenProvider provider = new QwenProvider(url, model, apiKey, credentialsId);
             try {

--- a/src/test/java/io/jenkins/plugins/explain_error/ExplainErrorFolderPropertyTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/ExplainErrorFolderPropertyTest.java
@@ -207,11 +207,12 @@ class ExplainErrorFolderPropertyTest {
     }
 
     @Test
-    void descriptorListsQuotaWindowOptions(JenkinsRule jenkins) {
+    void descriptorListsQuotaWindowOptions(JenkinsRule jenkins) throws Exception {
         ExplainErrorFolderProperty.DescriptorImpl descriptor =
                 jenkins.jenkins.getDescriptorByType(ExplainErrorFolderProperty.DescriptorImpl.class);
+        Folder folder = jenkins.jenkins.createProject(Folder.class, "test-folder");
 
-        ListBoxModel items = descriptor.doFillQuotaWindowItems();
+        ListBoxModel items = descriptor.doFillQuotaWindowItems(folder);
 
         assertEquals(2, items.size());
         assertEquals("Hourly", items.get(0).name);

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.cloudbees.hudson.plugins.folder.Folder;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -343,6 +344,55 @@ class AzureOpenAIProviderTest {
                 "gpt-5-pro",
                 "2025-01-01-preview",
                 "azure-test-responses-key",
+                AzureOpenAIProvider.ApiType.RESPONSES.name());
+
+        assertEquals(FormValidation.Kind.OK, validation.kind);
+        assertEquals("/openai/v1/responses", requestPath.get());
+
+        JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
+        assertEquals("gpt-5-pro", payload.path("model").asText());
+        assertEquals(32, payload.path("max_output_tokens").asInt());
+        assertEquals("minimal", payload.path("reasoning").path("effort").asText());
+        assertEquals("low", payload.path("text").path("verbosity").asText());
+        assertEquals("Test the connection.", payload.path("input").asText());
+        assertFalse(requestBody.get().contains("Return ONLY valid JSON"));
+    }
+
+    @Test
+    void descriptorTestConfigurationWithItemContext(JenkinsRule jenkins) throws Exception {
+        addStringCredential("azure-item-context-key", "item-context-key");
+
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        AtomicReference<String> requestBody = new AtomicReference<>();
+
+        server.createContext("/openai/v1/responses", new JsonHandler(exchange -> {
+            requestPath.set(exchange.getRequestURI().toString());
+            requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            return """
+                    {
+                      "output": [
+                        {
+                          "type": "message",
+                          "content": [
+                            {
+                              "type": "output_text",
+                              "text": "Configuration test successful"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """;
+        }));
+
+        AzureOpenAIProvider.DescriptorImpl descriptor = new AzureOpenAIProvider.DescriptorImpl();
+        Folder folder = jenkins.jenkins.createProject(Folder.class, "test-folder");
+        FormValidation validation = descriptor.doTestConfiguration(
+                folder,
+                "http://127.0.0.1:" + server.getAddress().getPort(),
+                "gpt-5-pro",
+                "2025-01-01-preview",
+                "azure-item-context-key",
                 AzureOpenAIProvider.ApiType.RESPONSES.name());
 
         assertEquals(FormValidation.Kind.OK, validation.kind);

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProviderTest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import hudson.model.Item;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
@@ -337,6 +338,7 @@ class AzureOpenAIProviderTest {
 
         AzureOpenAIProvider.DescriptorImpl descriptor = new AzureOpenAIProvider.DescriptorImpl();
         FormValidation validation = descriptor.doTestConfiguration(
+                null,
                 "http://127.0.0.1:" + server.getAddress().getPort(),
                 "gpt-5-pro",
                 "2025-01-01-preview",


### PR DESCRIPTION
### Description

Non-admin users were blocked from saving folder/job configurations because ExplainErrorFolderProperty and all provider descriptors used Jenkins.get().checkPermission(Jenkins.ADMINISTER) in their doFill*, doCheck*, and doTestConfiguration methods.

- Add checkConfigurePermission() helper to BaseProviderDescriptor: checks Item.CONFIGURE on the ancestor Item context, falls back to Jenkins.ADMINISTER in global context.
- ExplainErrorFolderProperty.doFillQuotaWindowItems and doCheckMaxProviderCallsPerWindow: use @AncestorInPath AbstractFolder and check Item.CONFIGURE.
- All provider doTestConfiguration methods: accept @AncestorInPath Item context and delegate to checkConfigurePermission().
- Provider validation-only methods (doCheckUrl, doCheckRoleArn, etc.): remove ADMINISTER check (consistent with base class pattern).
- GlobalConfigurationImpl unchanged (system config is admin-only).
- Update tests for the new method signatures.

### Related Issues

Fixes #204

### Testing done

<!-- Please describe any testing done to verify the changes in this PR. -->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify below)

Assisted-by: DeepSeek v4 + Pi
