### PR TITLE
docs: clarify that AWS Bedrock requires the optional AWS SDK plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ This allows you to manage the plugin configuration alongside your other Jenkins 
 - **Note**: Claude Opus 4.7 and newer models have deprecated the `temperature` parameter. See [model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations) for migration details.
 
 ### AWS Bedrock
+- **Requires**: the [AWS SDK 2.x](https://plugins.jenkins.io/aws-java-sdk2/) plugin (`aws-java-sdk2-core`). This dependency is intentionally **optional** so installations that don't use Bedrock are not forced to carry the AWS SDK. As a result, **AWS Bedrock appears in the AI Provider list only after you install that plugin**. To enable it: **Manage Jenkins → Plugins → Available plugins**, search for `AWS SDK`, install the AWS SDK 2.x plugin, and restart Jenkins.
 - **Models**: `anthropic.claude-3-5-sonnet-20240620-v1:0`, `eu.anthropic.claude-3-5-sonnet-20240620-v1:0` (EU cross-region), `meta.llama3-8b-instruct-v1:0`, `us.amazon.nova-lite-v1:0`, etc.
 - **API Key**: Not required — uses AWS credential chain (instance profiles, environment variables, etc.)
 - **Region**: AWS region (e.g., `us-east-1`, `eu-west-1`). Optional — defaults to AWS SDK region resolution

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/BedrockProviderRegistrationTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/BedrockProviderRegistrationTest.java
@@ -1,0 +1,31 @@
+package io.jenkins.plugins.explain_error.provider;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Guards that the AWS Bedrock provider is wired up as a selectable AI provider
+ * when its dependency is available.
+ *
+ * <p>The System configuration dropdown is populated by descriptor discovery over
+ * {@link BaseAIProvider}. The Bedrock descriptor is registered only when the
+ * {@code aws-java-sdk2-core} plugin is present — an intentionally optional
+ * dependency, so instances that do not use Bedrock are not forced to carry the
+ * AWS SDK. The test harness provides that dependency, so this test verifies the
+ * descriptor is correctly registered (via {@code @OptionalExtension} and
+ * {@code @Symbol}) whenever the AWS SDK plugin is installed.
+ */
+@WithJenkins
+class BedrockProviderRegistrationTest {
+
+    @Test
+    void bedrockProviderIsSelectable(JenkinsRule jenkins) {
+        boolean registered = jenkins.jenkins.getDescriptorList(BaseAIProvider.class).stream()
+                .anyMatch(descriptor -> descriptor instanceof BedrockProvider.DescriptorImpl);
+        assertTrue(registered,
+                "AWS Bedrock provider descriptor must be registered and selectable in the AI Provider list");
+    }
+}


### PR DESCRIPTION
### Description

Closes #210

User report that **AWS Bedrock** is missing from the AI Provider list (Manage Jenkins → System) after installing/upgrading the plugin.

This is intended behavior, not a defect. AWS Bedrock depends on the AWS SDK v2, which is large, so the `aws-java-sdk2-core` dependency is deliberately kept **optional** — otherwise every Explain Error user would carry the AWS SDK even if they never use Bedrock. The Bedrock descriptor is gated on that plugin via `@OptionalExtension(requirePlugins="aws-java-sdk2-core")`, so it only registers when the AWS SDK plugin is installed. On an instance without it, Bedrock simply doesn't appear (and nothing is logged, because nothing fails).

The gap is that this requirement was not documented, so the provider appears to "vanish" with no guidance. This PR fixes the discoverability rather than forcing the dependency on everyone.

### Changes

- `README.md`: document that AWS Bedrock requires the optional AWS SDK 2.x plugin (`aws-java-sdk2-core`), explain why it is optional, and give the install/enable steps.
- `BedrockProviderRegistrationTest`: assert the Bedrock descriptor is discoverable via the same mechanism the provider dropdown uses, guarding the descriptor wiring when the AWS SDK dependency is present.

The `aws-java-sdk2-core` dependency stays optional — no change to what every installation is required to carry.

### Related Issues

<!-- intentionally left blank for now -->

### Testing done

- Added `BedrockProviderRegistrationTest` verifying `getDescriptorList(BaseAIProvider.class)` contains `BedrockProvider.DescriptorImpl`.
- Note: the jenkins-test-harness always loads declared plugin dependencies (even optional ones), so the missing-plugin production condition is not reproducible in unit tests. Manual verification on a Jenkins instance without `aws-java-sdk2-core` pre-installed is recommended.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify below)