### PR TITLE
feat: add OpenAI Compatible provider for AI gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Whether it’s a compilation error, test failure, or deployment hiccup, this plu
 * **Automatic explanation on failure** — failed builds are explained without any pipeline change when the global toggle is enabled
 * **Workspace Context** *(opt-in)* — include selected workspace files for more accurate explanations
 * **AI auto-fix** *(experimental)* — automatically opens a pull request on GitHub, GitLab, or Bitbucket with AI-generated code changes when a build fails
-* **AI-powered explanations** via Anthropic Claude, AWS Bedrock, Azure OpenAI, DeepSeek, Google Gemini, LangGraph, Microsoft Foundry, Ollama, OpenAI GPT models, Qwen, or generic Okta-authenticated company AI gateways
+* **AI-powered explanations** via Anthropic Claude, AWS Bedrock, Azure OpenAI, DeepSeek, Google Gemini, LangGraph, Microsoft Foundry, Ollama, OpenAI GPT models, OpenAI-compatible gateways (LiteLLM, OpenWebUI, self-hosted proxies), Qwen, or generic Okta-authenticated company AI gateways
 * **Folder-level configuration** so teams can use project-specific settings
 * **Smart provider management** — LangChain4j handles most providers automatically
 * **Customizable**: set provider, model, API endpoint, Okta token flow settings, log filters, and more
@@ -65,9 +65,9 @@ Whether it’s a compilation error, test failure, or deployment hiccup, this plu
 | Setting | Description | Default |
 |---------|-------------|---------|
 | **Enable AI Error Explanation** | Toggle plugin functionality | ✅ Enabled |
-| **AI Provider** | Choose between Anthropic (Claude), AWS Bedrock, Azure OpenAI, Custom Okta AI, DeepSeek, Google Gemini, LangGraph, Microsoft Foundry, Ollama, OpenAI, or Qwen | `OpenAI` |
-| **API Key** | Your AI provider API key | Used by OpenAI, Microsoft Foundry, Anthropic, Gemini, DeepSeek, and Qwen providers |
-| **API URL** | AI service endpoint | **Leave empty** for official APIs where supported. **Required for Custom Okta AI and Ollama providers.** Optional Bedrock Runtime endpoint override for private VPC endpoints. |
+| **AI Provider** | Choose between Anthropic (Claude), AWS Bedrock, Azure OpenAI, Custom Okta AI, DeepSeek, Google Gemini, LangGraph, Microsoft Foundry, Ollama, OpenAI, OpenAI Compatible, or Qwen | `OpenAI` |
+| **API Key** | Your AI provider API key | Used by OpenAI, Microsoft Foundry, Anthropic, Gemini, DeepSeek, and Qwen providers. Optional for OpenAI Compatible and Ollama providers |
+| **API URL** | AI service endpoint | **Leave empty** for official APIs where supported. **Required for Custom Okta AI, Ollama, and OpenAI Compatible providers.** Optional Bedrock Runtime endpoint override for private VPC endpoints. |
 | **AI Model** | Model to use for analysis | *Required*.  Specify the model name offered by your selected AI provider |
 | **Temperature** | Creativity control (0.0–2.0). Leave empty to use the provider default. | *Optional* |
 | **Language** | Language for AI explanations (e.g. `English`, `中文`, `日本語`). Can be overridden at folder and step level. | `English` |
@@ -247,6 +247,18 @@ unclassified:
       - Check if the error might be caused by a builder crash and suggest restarting the pipeline
 ```
 
+**OpenAI Compatible Configuration (LiteLLM / custom gateways):**
+```yaml
+unclassified:
+  explainError:
+    aiProvider:
+      openaiCompatible:
+        url: "https://litellm.example.com" # Required: base URL of your gateway
+        model: "azure/gpt-4o" # Any model name exposed by the gateway
+        # apiKey: "${GATEWAY_API_KEY}" # Optional, sent as Bearer token
+    enableExplanation: true
+```
+
 **Environment Variable Example:**
 ```bash
 export AI_API_KEY="your-api-key-here"
@@ -347,6 +359,13 @@ This allows you to manage the plugin configuration alongside your other Jenkins 
 - **API Key**: Not required by default (unless your Ollama server is secured)
 - **Endpoint**: `http://localhost:11434` (or your Ollama server URL)
 - **Best for**: Private, local, or open-source LLMs; no external API usage or cost
+
+### OpenAI Compatible
+- **Models**: Any model exposed by your gateway, e.g. `gpt-4o`, `azure/gpt-4o`, `claude-3-5-sonnet`, `llama-3.1-70b`
+- **API Key**: Optional. Sent as a standard `Authorization: Bearer` header; leave empty for unauthenticated gateways
+- **Endpoint**: Base URL of any OpenAI-compatible gateway, e.g. `https://litellm.example.com` (LiteLLM), `https://openwebui.example.com/api/v1` (OpenWebUI), or a self-hosted proxy. `/chat/completions` is appended automatically
+- **Redirects**: HTTP redirects (e.g. `http` to `https` upgrades behind load balancers) are followed automatically
+- **Best for**: Enterprises standardizing on AI gateways, proxies, or self-hosted LLM platforms; works with LiteLLM, OpenWebUI, Azure OpenAI gateways, and other OpenAI-compatible backends
 
 ### OpenAI
 - **Models**: `gpt-4`, `gpt-4-turbo`, `gpt-3.5-turbo`, etc.

--- a/docs/auto-fix.md
+++ b/docs/auto-fix.md
@@ -27,7 +27,7 @@ build is marked with status `FAILED` — the original build result is not affect
 |-------------|---------|
 | Jenkins | 2.528.3 or higher |
 | Java | 17+ |
-| AI provider | Any supported provider configured in global settings (Anthropic Claude, AWS Bedrock, Azure OpenAI, Custom Okta, DeepSeek, Google Gemini, Microsoft Foundry, Ollama, OpenAI, Qwen) |
+| AI provider | Any supported provider configured in global settings (Anthropic Claude, AWS Bedrock, Azure OpenAI, Custom Okta, DeepSeek, Google Gemini, Microsoft Foundry, Ollama, OpenAI, OpenAI Compatible, Qwen) |
 | SCM | GitHub.com, GitHub Enterprise, GitLab.com, GitLab self-managed, Bitbucket Cloud, or Bitbucket Server / Data Center |
 | Token | Personal Access Token (PAT) with **read + write** access to the repository |
 

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/BaseAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/BaseAIProvider.java
@@ -326,7 +326,12 @@ public abstract class BaseAIProvider extends AbstractDescribableImpl<BaseAIProvi
     protected final String getProxyAuthorizationHeader() {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         ProxyConfiguration proxyConfiguration = jenkins != null ? jenkins.getProxy() : null;
-        if (proxyConfiguration == null || proxyConfiguration.getUserName() == null) {
+        // Require a proxy host as well as a user name: newJenkinsHttpClientBuilder()
+        // only routes through the proxy when a host is configured, and without one
+        // this header would be sent to the origin server, leaking the credentials.
+        if (proxyConfiguration == null
+                || proxyConfiguration.getName() == null
+                || proxyConfiguration.getUserName() == null) {
             return null;
         }
         Secret secretPassword = proxyConfiguration.getSecretPassword();

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/BaseAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/BaseAIProvider.java
@@ -2,11 +2,18 @@ package io.jenkins.plugins.explain_error.provider;
 
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
+import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang3.StringUtils;
@@ -25,6 +32,7 @@ import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.security.AccessControlled;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import io.jenkins.plugins.explain_error.ExplanationException;
 import io.jenkins.plugins.explain_error.JenkinsLogAnalysis;
 import jenkins.model.Jenkins;
@@ -273,23 +281,64 @@ public abstract class BaseAIProvider extends AbstractDescribableImpl<BaseAIProvi
     }
 
     protected final HttpClient.Builder newJenkinsHttpClientBuilder() {
-        HttpClient.Builder builder;
+        HttpClient.Builder builder = HttpClient.newBuilder();
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         ProxyConfiguration proxyConfiguration = jenkins != null ? jenkins.getProxy() : null;
-        if (proxyConfiguration != null) {
-            builder = proxyConfiguration.newHttpClientBuilder();
-        } else {
-            builder = HttpClient.newBuilder();
+        if (proxyConfiguration != null && proxyConfiguration.getName() != null) {
+            builder.proxy(new ProxySelector() {
+                @Override
+                public List<Proxy> select(URI uri) {
+                    String scheme = uri.getScheme();
+                    if (scheme != null && (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+                        // Honors the noProxyHost exclusions, same as Jenkins core.
+                        return List.of(proxyConfiguration.createProxy(uri.getHost()));
+                    }
+                    return List.of(Proxy.NO_PROXY);
+                }
+
+                @Override
+                public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+                    // Ignore, same as Jenkins core's own proxy selector.
+                }
+            });
         }
+        // Deliberately no Authenticator: Jenkins core attaches one when the proxy has
+        // credentials, and since JDK-8326949 (fixed only in JDK 24) the JDK HttpClient
+        // drops user-set Authorization headers whenever an Authenticator is present.
+        // Proxy credentials are instead sent preemptively via Proxy-Authorization,
+        // see getProxyAuthorizationHeader() and ProxyAwareHttpClient.
         // Follow redirects returned by AI gateways and proxies (e.g. http -> https
         // upgrades behind load balancers). Matches Jenkins core's own HttpClient
         // behaviour; the default is NEVER, which fails any 3xx response.
         return builder.followRedirects(HttpClient.Redirect.NORMAL);
     }
 
+    /**
+     * Preemptive {@code Proxy-Authorization} header value for the Jenkins proxy, or
+     * {@code null} when no proxy credentials are configured.
+     *
+     * <p>Sent as a user-set header instead of relying on a JDK {@link java.net.Authenticator}:
+     * with an Authenticator present, the JDK HttpClient drops user-set Authorization
+     * headers (JDK-8326949, fixed only in JDK 24), which silently removes the API key
+     * from AI requests on Jenkins instances with an authenticated proxy.
+     */
+    @CheckForNull
+    protected final String getProxyAuthorizationHeader() {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        ProxyConfiguration proxyConfiguration = jenkins != null ? jenkins.getProxy() : null;
+        if (proxyConfiguration == null || proxyConfiguration.getUserName() == null) {
+            return null;
+        }
+        Secret secretPassword = proxyConfiguration.getSecretPassword();
+        String password = secretPassword == null ? "" : Secret.toString(secretPassword);
+        String credentials = proxyConfiguration.getUserName() + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+
     protected final HttpClientBuilder newLangChainHttpClientBuilder() {
-        return new JdkHttpClientBuilder()
-                .httpClientBuilder(newJenkinsHttpClientBuilder());
+        return new ProxyAwareHttpClientBuilder(
+                new JdkHttpClientBuilder().httpClientBuilder(newJenkinsHttpClientBuilder()),
+                getProxyAuthorizationHeader());
     }
 
     public String getProviderName() {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/BaseAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/BaseAIProvider.java
@@ -273,12 +273,18 @@ public abstract class BaseAIProvider extends AbstractDescribableImpl<BaseAIProvi
     }
 
     protected final HttpClient.Builder newJenkinsHttpClientBuilder() {
+        HttpClient.Builder builder;
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         ProxyConfiguration proxyConfiguration = jenkins != null ? jenkins.getProxy() : null;
         if (proxyConfiguration != null) {
-            return proxyConfiguration.newHttpClientBuilder();
+            builder = proxyConfiguration.newHttpClientBuilder();
+        } else {
+            builder = HttpClient.newBuilder();
         }
-        return HttpClient.newBuilder();
+        // Follow redirects returned by AI gateways and proxies (e.g. http -> https
+        // upgrades behind load balancers). Matches Jenkins core's own HttpClient
+        // behaviour; the default is NEVER, which fails any 3xx response.
+        return builder.followRedirects(HttpClient.Redirect.NORMAL);
     }
 
     protected final HttpClientBuilder newLangChainHttpClientBuilder() {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/CustomOktaAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/CustomOktaAIProvider.java
@@ -243,13 +243,14 @@ public class CustomOktaAIProvider extends BaseAIProvider {
         String credentials = getClientId() + ':' + Secret.toString(getClientSecret());
         String basicAuth = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
 
-        HttpRequest request = HttpRequest.newBuilder(URI.create(getTokenUrl()))
+        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(getTokenUrl()))
                 .timeout(Duration.ofSeconds(resolveTimeoutSeconds()))
                 .header("Accept", "application/json")
                 .header("Content-Type", "application/x-www-form-urlencoded")
                 .header("Authorization", "Basic " + basicAuth)
-                .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
-                .build();
+                .POST(HttpRequest.BodyPublishers.ofString(body.toString()));
+        withProxyAuthorization(builder);
+        HttpRequest request = builder.build();
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
         if (response.statusCode() >= 400) {
@@ -276,13 +277,14 @@ public class CustomOktaAIProvider extends BaseAIProvider {
 
     private String requestRawContent(HttpClient client, String accessToken, String requestBody)
             throws IOException, InterruptedException, ExplanationException {
-        HttpRequest request = HttpRequest.newBuilder(buildChatUri())
+        HttpRequest.Builder builder = HttpRequest.newBuilder(buildChatUri())
                 .timeout(Duration.ofSeconds(resolveTimeoutSeconds()))
                 .header("Accept", "application/json")
                 .header("Content-Type", "application/json")
                 .header(resolveAccessTokenHeader(), buildAccessTokenHeaderValue(accessToken))
-                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
-                .build();
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody));
+        withProxyAuthorization(builder);
+        HttpRequest request = builder.build();
 
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.fine("Sending Custom Okta AI request to " + request.uri());
@@ -296,6 +298,13 @@ public class CustomOktaAIProvider extends BaseAIProvider {
 
         JsonNode json = OBJECT_MAPPER.readTree(response.body());
         return extractAssistantContent(json);
+    }
+
+    private void withProxyAuthorization(HttpRequest.Builder builder) {
+        String proxyAuthorization = getProxyAuthorizationHeader();
+        if (proxyAuthorization != null) {
+            builder.header("Proxy-Authorization", proxyAuthorization);
+        }
     }
 
     private URI buildChatUri() {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider.java
@@ -1,0 +1,215 @@
+package io.jenkins.plugins.explain_error.provider;
+
+import dev.langchain4j.exception.AuthenticationException;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.model.chat.Capability;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.ResponseFormat;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.service.AiServices;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Item;
+import hudson.model.TaskListener;
+import hudson.util.FormValidation;
+import hudson.util.Secret;
+import io.jenkins.plugins.explain_error.ExplanationException;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
+
+/**
+ * Generic provider for any OpenAI-compatible endpoint: LiteLLM, OpenWebUI,
+ * self-hosted AI proxies and enterprise API gateways.
+ *
+ * <p>Unlike {@link OpenAIProvider}, the API key is optional so that
+ * unauthenticated local gateways and proxies can be used without one.
+ * The model name is free text because gateway model names are defined by the
+ * gateway (e.g. {@code gpt-4o}, {@code azure/gpt-4o}, {@code claude-3-5-sonnet}).
+ */
+public class OpenAICompatibleProvider extends BaseAIProvider {
+
+    private static final Logger LOGGER = Logger.getLogger(OpenAICompatibleProvider.class.getName());
+
+    private Secret apiKey;
+
+    @DataBoundConstructor
+    public OpenAICompatibleProvider(String url, String model, Secret apiKey) {
+        super(Util.fixEmptyAndTrim(url), Util.fixEmptyAndTrim(model));
+        this.apiKey = apiKey;
+    }
+
+    public Secret getApiKey() {
+        return apiKey;
+    }
+
+    @Override
+    public Assistant createAssistant() {
+        return createAssistant(null);
+    }
+
+    @Override
+    public Assistant createAssistant(@CheckForNull Double temperature) {
+        ChatModel model = buildChatModel(temperature);
+        return AiServices.create(Assistant.class, model);
+    }
+
+    @Override
+    public io.jenkins.plugins.explain_error.autofix.FixAssistant createFixAssistant() {
+        ChatModel model = buildChatModel(null);
+        return AiServices.create(io.jenkins.plugins.explain_error.autofix.FixAssistant.class, model);
+    }
+
+    private ChatModel buildChatModel(@CheckForNull Double temperature) {
+        var builder = OpenAiChatModel.builder()
+                .httpClientBuilder(newLangChainHttpClientBuilder())
+                .baseUrl(getUrl())
+                .modelName(getModel())
+                .responseFormat(ResponseFormat.JSON)
+                .logRequests(LOGGER.isLoggable(Level.FINE))
+                .logResponses(LOGGER.isLoggable(Level.FINE));
+        String resolvedApiKey = Util.fixEmptyAndTrim(Secret.toString(apiKey));
+        if (resolvedApiKey != null) {
+            builder.apiKey(resolvedApiKey);
+        }
+        if (temperature != null) {
+            builder.temperature(temperature);
+        }
+        return new ErrorMappingChatModel(builder.build());
+    }
+
+    @Override
+    public boolean isNotValid(@CheckForNull TaskListener listener) {
+        if (listener != null) {
+            if (Util.fixEmptyAndTrim(getUrl()) == null) {
+                listener.getLogger().println("No URL configured for OpenAI Compatible.");
+            } else if (Util.fixEmptyAndTrim(getModel()) == null) {
+                listener.getLogger().println("No model configured for OpenAI Compatible.");
+            }
+        }
+        return Util.fixEmptyAndTrim(getUrl()) == null
+                || Util.fixEmptyAndTrim(getModel()) == null;
+    }
+
+    /**
+     * Wraps a {@link ChatModel} to translate low-level HTTP failures — including
+     * non-standard error responses returned by AI gateways and proxies — into
+     * clear, actionable messages.
+     */
+    private static class ErrorMappingChatModel implements ChatModel {
+
+        private final ChatModel delegate;
+
+        ErrorMappingChatModel(ChatModel delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ChatResponse chat(ChatRequest chatRequest) {
+            try {
+                return delegate.chat(chatRequest);
+            } catch (AuthenticationException e) {
+                // langchain4j maps HTTP 401/403 to AuthenticationException; the message
+                // is the raw gateway response body, which is unhelpful on its own.
+                throw new RuntimeException(buildAuthErrorMessage(e), e);
+            } catch (HttpException e) {
+                throw new RuntimeException(buildHttpErrorMessage(e), e);
+            }
+        }
+
+        @Override
+        public Set<Capability> supportedCapabilities() {
+            return delegate.supportedCapabilities();
+        }
+
+        private static String buildAuthErrorMessage(AuthenticationException e) {
+            String body = e.getMessage();
+            int statusCode = findHttpStatusCode(e);
+            String statusPart = statusCode > 0 ? " (HTTP " + statusCode + ")" : "";
+            return "Authentication failed" + statusPart + ". "
+                    + "Verify that the API key is correct and that the endpoint accepts Bearer token authentication."
+                    + (StringUtils.isBlank(body) ? "" : " Gateway response: " + body);
+        }
+
+        private static String buildHttpErrorMessage(HttpException e) {
+            String body = e.getMessage();
+            return "Request to the AI endpoint failed with HTTP " + e.statusCode()
+                    + (StringUtils.isBlank(body) ? "." : ": " + body);
+        }
+
+        private static int findHttpStatusCode(Throwable throwable) {
+            Throwable current = throwable;
+            while (current != null) {
+                if (current instanceof HttpException httpException) {
+                    return httpException.statusCode();
+                }
+                current = current.getCause();
+            }
+            return -1;
+        }
+    }
+
+    @Extension
+    @Symbol("openaiCompatible")
+    public static class DescriptorImpl extends BaseProviderDescriptor {
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "OpenAI Compatible";
+        }
+
+        @Override
+        public String getDefaultModel() {
+            return "";
+        }
+
+        @POST
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
+        public FormValidation doCheckUrl(@QueryParameter String value) {
+            if (value == null || value.isBlank()) {
+                return FormValidation.error("URL is required.");
+            }
+            return super.doCheckUrl(value);
+        }
+
+        @POST
+        @SuppressWarnings("lgtm[jenkins/no-permission-check]")
+        public FormValidation doCheckModel(@QueryParameter String value) {
+            if (value == null || value.isBlank()) {
+                return FormValidation.error("Model is required.");
+            }
+            return FormValidation.ok();
+        }
+
+        /**
+         * Method to test the AI API configuration.
+         * This is called when the "Test Configuration" button is clicked.
+         */
+        @POST
+        public FormValidation doTestConfiguration(@AncestorInPath Item context,
+                                                  @QueryParameter("apiKey") Secret apiKey,
+                                                  @QueryParameter("url") String url,
+                                                  @QueryParameter("model") String model) throws ExplanationException {
+            checkConfigurePermission(context);
+
+            OpenAICompatibleProvider provider = new OpenAICompatibleProvider(url, model, apiKey);
+            try {
+                provider.explainError("Send 'Configuration test successful' to me.", null);
+                return FormValidation.ok("Configuration test successful! API connection is working properly.");
+            } catch (ExplanationException e) {
+                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider.java
@@ -174,6 +174,7 @@ public class OpenAICompatibleProvider extends BaseAIProvider {
             return "";
         }
 
+        @Override
         @POST
         @SuppressWarnings("lgtm[jenkins/no-permission-check]")
         public FormValidation doCheckUrl(@QueryParameter String value) {

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/ProxyAwareHttpClient.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/ProxyAwareHttpClient.java
@@ -1,0 +1,109 @@
+package io.jenkins.plugins.explain_error.provider;
+
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+
+/**
+ * langchain4j {@link HttpClientBuilder} that adds a preemptive
+ * {@code Proxy-Authorization} header to every request when the Jenkins proxy
+ * requires credentials.
+ *
+ * <p>Jenkins core's {@code ProxyConfiguration.newHttpClientBuilder()} attaches a
+ * {@link java.net.Authenticator} to the JDK {@link java.net.http.HttpClient} for
+ * proxy authentication. Since JDK-8326949 (fixed only in JDK 24), the JDK HTTP
+ * client silently drops user-set {@code Authorization} headers whenever an
+ * Authenticator is present, so API keys never reach the AI endpoint on Jenkins
+ * instances with an authenticated proxy. To work around this, no Authenticator is
+ * used; instead the proxy credentials are sent preemptively as a user-set
+ * {@code Proxy-Authorization} header. The JDK attaches that header to the CONNECT
+ * request of tunneled connections and filters proxy-* headers from direct and
+ * tunneled inner requests, so credentials never leak to the origin server.
+ */
+class ProxyAwareHttpClientBuilder implements HttpClientBuilder {
+
+    private final HttpClientBuilder delegate;
+
+    @CheckForNull
+    private final String proxyAuthorizationHeader;
+
+    ProxyAwareHttpClientBuilder(HttpClientBuilder delegate, @CheckForNull String proxyAuthorizationHeader) {
+        this.delegate = delegate;
+        this.proxyAuthorizationHeader = proxyAuthorizationHeader;
+    }
+
+    @Override
+    public Duration connectTimeout() {
+        return delegate.connectTimeout();
+    }
+
+    @Override
+    public HttpClientBuilder connectTimeout(Duration connectTimeout) {
+        delegate.connectTimeout(connectTimeout);
+        return this;
+    }
+
+    @Override
+    public Duration readTimeout() {
+        return delegate.readTimeout();
+    }
+
+    @Override
+    public HttpClientBuilder readTimeout(Duration readTimeout) {
+        delegate.readTimeout(readTimeout);
+        return this;
+    }
+
+    @Override
+    public HttpClient build() {
+        HttpClient httpClient = delegate.build();
+        return proxyAuthorizationHeader == null
+                ? httpClient
+                : new ProxyAwareHttpClient(httpClient, proxyAuthorizationHeader);
+    }
+}
+
+/**
+ * Delegating {@link HttpClient} that injects the Jenkins proxy credentials into
+ * every request, see {@link ProxyAwareHttpClientBuilder}.
+ */
+class ProxyAwareHttpClient implements HttpClient {
+
+    private final HttpClient delegate;
+
+    private final String proxyAuthorizationHeader;
+
+    ProxyAwareHttpClient(HttpClient delegate, String proxyAuthorizationHeader) {
+        this.delegate = delegate;
+        this.proxyAuthorizationHeader = proxyAuthorizationHeader;
+    }
+
+    @Override
+    public SuccessfulHttpResponse execute(HttpRequest request) throws HttpException {
+        return delegate.execute(withProxyAuthorizationHeader(request));
+    }
+
+    @Override
+    public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener eventListener) {
+        delegate.execute(withProxyAuthorizationHeader(request), parser, eventListener);
+    }
+
+    private HttpRequest withProxyAuthorizationHeader(HttpRequest request) {
+        return HttpRequest.builder()
+                .method(request.method())
+                .url(request.url())
+                .headers(new LinkedHashMap<>(request.headers()))
+                .addHeader("Proxy-Authorization", proxyAuthorizationHeader)
+                .formDataFields(request.formDataFields())
+                .formDataFiles(request.formDataFiles())
+                .body(request.body())
+                .build();
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider/config.jelly
@@ -1,0 +1,18 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"  xmlns:f="/lib/form">
+  <f:entry title="URL" field="url">
+    <f:textbox clazz="required"/>
+  </f:entry>
+
+  <f:entry title="API Key" field="apiKey">
+    <f:password/>
+  </f:entry>
+
+  <f:entry title="Model" field="model">
+    <f:textbox clazz="required"/>
+  </f:entry>
+
+  <f:validateButton title="Test Configuration" progress="Testing..."
+                    method="testConfiguration" with="apiKey,url,model" />
+
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider/help-apiKey.html
+++ b/src/main/resources/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider/help-apiKey.html
@@ -1,0 +1,4 @@
+<div>
+  <p>Optional. The API key or token for the gateway. It is sent as a standard <code>Authorization: Bearer &lt;key&gt;</code> header.</p>
+  <p>Leave empty when the gateway does not require authentication (e.g. a local unauthenticated proxy).</p>
+</div>

--- a/src/main/resources/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider/help-model.html
+++ b/src/main/resources/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider/help-model.html
@@ -1,0 +1,4 @@
+<div>
+  <p>The model name as exposed by your gateway, for example <em>gpt-4o</em>, <em>azure/gpt-4o</em>, <em>claude-3-5-sonnet</em> or <em>llama-3.1-70b</em>.</p>
+  <p>Gateway model names are defined by the gateway itself, so any name accepted by your gateway can be used.</p>
+</div>

--- a/src/main/resources/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider/help-url.html
+++ b/src/main/resources/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider/help-url.html
@@ -1,0 +1,10 @@
+<div>
+  <p>The base URL of your OpenAI-compatible gateway, for example:</p>
+  <ul>
+    <li><em>https://litellm.example.com</em> for a LiteLLM proxy</li>
+    <li><em>https://openwebui.example.com/api/v1</em> for an OpenWebUI backend</li>
+    <li><em>http://localhost:8000/v1</em> for a self-hosted proxy</li>
+  </ul>
+  <p><code>/chat/completions</code> is appended automatically. The URL must use <code>http</code> or <code>https</code>.</p>
+  <p>HTTP redirects (e.g. <code>http</code> to <code>https</code> upgrades behind load balancers) are followed automatically.</p>
+</div>

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProviderTest.java
@@ -1,0 +1,219 @@
+package io.jenkins.plugins.explain_error.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import hudson.util.Secret;
+import io.jenkins.plugins.explain_error.ExplanationException;
+import io.jenkins.plugins.explain_error.autofix.FixAssistant;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class OpenAICompatibleProviderTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private HttpServer server;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void explainErrorUsesCustomBaseUrlWithBearerToken() throws Exception {
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        AtomicReference<String> authorizationHeader = new AtomicReference<>();
+        AtomicReference<String> requestBody = new AtomicReference<>();
+
+        server.createContext("/chat/completions", new JsonHandler(exchange -> {
+            requestPath.set(exchange.getRequestURI().toString());
+            authorizationHeader.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            return chatCompletionResponse("{\"errorSummary\":\"Gateway worked\",\"resolutionSteps\":[\"Check the gateway config\"],"
+                    + "\"bestPractices\":[\"Use gateway model names\"],\"errorSignature\":\"FAILURE: gateway path verified\"}");
+        }));
+
+        String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+        OpenAICompatibleProvider provider = new OpenAICompatibleProvider(
+                endpoint, "gateway-model", Secret.fromString("test-gateway-key"));
+
+        String explanation = provider.explainError("FAILURE: sample error", null, "English", null);
+
+        assertEquals("/chat/completions", requestPath.get());
+        assertEquals("Bearer test-gateway-key", authorizationHeader.get());
+
+        JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
+        assertEquals("gateway-model", payload.path("model").asText());
+        assertTrue(explanation.contains("Gateway worked"));
+        assertTrue(explanation.contains("Check the gateway config"));
+    }
+
+    @Test
+    void explainErrorWithoutApiKeyOmitsAuthorizationHeader() throws Exception {
+        AtomicReference<String> authorizationHeader = new AtomicReference<>();
+
+        server.createContext("/chat/completions", new JsonHandler(exchange -> {
+            authorizationHeader.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            return chatCompletionResponse("{\"errorSummary\":\"No auth needed\"}");
+        }));
+
+        String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+        OpenAICompatibleProvider provider = new OpenAICompatibleProvider(endpoint, "gateway-model", null);
+
+        String explanation = provider.explainError("FAILURE: sample error", null);
+
+        assertNull(authorizationHeader.get(), "No Authorization header should be sent when apiKey is empty");
+        assertTrue(explanation.contains("No auth needed"));
+    }
+
+    @Test
+    void explainErrorFollowsRedirects() throws Exception {
+        AtomicReference<String> redirectedPath = new AtomicReference<>();
+
+        HttpServer targetServer = HttpServer.create(new InetSocketAddress(0), 0);
+        targetServer.createContext("/chat/completions", new JsonHandler(exchange -> {
+            redirectedPath.set(exchange.getRequestURI().toString());
+            return chatCompletionResponse("{\"errorSummary\":\"Redirect followed\"}");
+        }));
+        targetServer.start();
+
+        try {
+            String targetUrl = "http://127.0.0.1:" + targetServer.getAddress().getPort() + "/chat/completions";
+            server.createContext("/chat/completions", exchange -> {
+                exchange.getResponseHeaders().set("Location", targetUrl);
+                sendResponse(exchange, 307, "");
+            });
+
+            String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+            OpenAICompatibleProvider provider = new OpenAICompatibleProvider(
+                    endpoint, "gateway-model", Secret.fromString("test-gateway-key"));
+
+            String explanation = provider.explainError("FAILURE: sample error", null);
+
+            assertEquals("/chat/completions", redirectedPath.get(), "redirected request should reach the target endpoint");
+            assertTrue(explanation.contains("Redirect followed"));
+        } finally {
+            targetServer.stop(0);
+        }
+    }
+
+    @Test
+    void explainErrorWith401ReturnsClearAuthenticationMessage() throws Exception {
+        server.createContext("/chat/completions", exchange -> {
+            sendResponse(exchange, 401, "{\"error\":{\"message\":\"Invalid API key\"}}");
+        });
+
+        String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+        OpenAICompatibleProvider provider = new OpenAICompatibleProvider(
+                endpoint, "gateway-model", Secret.fromString("wrong-key"));
+
+        ExplanationException result = org.junit.jupiter.api.Assertions.assertThrows(
+                ExplanationException.class, () -> provider.explainError("FAILURE: sample error", null));
+
+        assertTrue(result.getMessage().contains("Authentication failed (HTTP 401)"),
+                "Expected authentication hint in: " + result.getMessage());
+        assertTrue(result.getMessage().contains("Invalid API key"),
+                "Expected gateway response body in: " + result.getMessage());
+    }
+
+    @Test
+    void fixAssistantUsesSameEndpoint() throws Exception {
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        AtomicReference<String> requestBody = new AtomicReference<>();
+
+        server.createContext("/chat/completions", new JsonHandler(exchange -> {
+            requestPath.set(exchange.getRequestURI().toString());
+            requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            return chatCompletionResponse("{\"fixable\":true,\"explanation\":\"Update the Jenkinsfile\","
+                    + "\"confidence\":\"high\",\"fixType\":\"config\",\"changes\":[]}");
+        }));
+
+        String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+        OpenAICompatibleProvider provider = new OpenAICompatibleProvider(
+                endpoint, "gateway-fix-model", Secret.fromString("fix-key"));
+
+        FixAssistant assistant = provider.createFixAssistant();
+        String result = assistant.suggestFix("FAILURE: job failed");
+
+        assertEquals("/chat/completions", requestPath.get());
+        JsonNode payload = OBJECT_MAPPER.readTree(requestBody.get());
+        assertEquals("gateway-fix-model", payload.path("model").asText());
+        assertTrue(result.contains("\"fixable\":true"));
+    }
+
+    private static void sendResponse(HttpExchange exchange, int statusCode, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream outputStream = exchange.getResponseBody()) {
+            outputStream.write(bytes);
+        }
+    }
+
+    private static String chatCompletionResponse(String content) {
+        return """
+                {
+                  "id": "chatcmpl-test",
+                  "object": "chat.completion",
+                  "created": 0,
+                  "model": "gateway-model",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": {
+                        "role": "assistant",
+                        "content": "%s"
+                      },
+                      "finish_reason": "stop"
+                    }
+                  ]
+                }
+                """.formatted(content.replace("\"", "\\\"").replace("\n", "\\n"));
+    }
+
+    private interface ResponseSupplier {
+        String get(HttpExchange exchange) throws IOException;
+    }
+
+    private static class JsonHandler implements HttpHandler {
+
+        private final ResponseSupplier supplier;
+
+        JsonHandler(ResponseSupplier supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String response = supplier.get(exchange);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+                outputStream.write(bytes);
+            }
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/ProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/ProviderTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.explain_error.provider;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -316,15 +317,15 @@ class ProviderTest {
     void testOpenAICompatibleNullApiKey() {
         // apiKey is optional for OpenAI-compatible gateways (e.g. unauthenticated local proxies)
         BaseAIProvider provider = new OpenAICompatibleProvider("http://localhost:1234", "test-model", null);
-        assertTrue(provider.isNotValid(null) || !provider.isNotValid(null),
-                "isNotValid should complete without exception when apiKey is null");
+        assertFalse(provider.isNotValid(null),
+                "provider with url and model set must be valid even when apiKey is null");
     }
 
     @Test
     void testOpenAICompatibleEmptyApiKey() {
         BaseAIProvider provider = new OpenAICompatibleProvider("http://localhost:1234", "test-model", Secret.fromString(""));
-        assertTrue(provider.isNotValid(null) || !provider.isNotValid(null),
-                "isNotValid should complete without exception when apiKey is empty");
+        assertFalse(provider.isNotValid(null),
+                "provider with url and model set must be valid even when apiKey is empty");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/ProviderTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/ProviderTest.java
@@ -277,6 +277,66 @@ class ProviderTest {
     }
 
     @Test
+    void testOpenAICompatibleNullUrl() {
+        BaseAIProvider provider = new OpenAICompatibleProvider(null, "test-model", Secret.fromString("test-key"));
+        ExplanationException result = assertThrows(ExplanationException.class,
+                () -> provider.explainError("Test error", null));
+
+        assertEquals("The provider is not properly configured.", result.getMessage());
+    }
+
+    @Test
+    void testOpenAICompatibleEmptyUrl() {
+        BaseAIProvider provider = new OpenAICompatibleProvider("", "test-model", Secret.fromString("test-key"));
+        ExplanationException result = assertThrows(ExplanationException.class,
+                () -> provider.explainError("Test error", null));
+
+        assertEquals("The provider is not properly configured.", result.getMessage());
+    }
+
+    @Test
+    void testOpenAICompatibleNullModel() {
+        BaseAIProvider provider = new OpenAICompatibleProvider("http://localhost:1234", null, Secret.fromString("test-key"));
+        ExplanationException result = assertThrows(ExplanationException.class,
+                () -> provider.explainError("Test error", null));
+
+        assertEquals("The provider is not properly configured.", result.getMessage());
+    }
+
+    @Test
+    void testOpenAICompatibleEmptyModel() {
+        BaseAIProvider provider = new OpenAICompatibleProvider("http://localhost:1234", "", Secret.fromString("test-key"));
+        ExplanationException result = assertThrows(ExplanationException.class,
+                () -> provider.explainError("Test error", null));
+
+        assertEquals("The provider is not properly configured.", result.getMessage());
+    }
+
+    @Test
+    void testOpenAICompatibleNullApiKey() {
+        // apiKey is optional for OpenAI-compatible gateways (e.g. unauthenticated local proxies)
+        BaseAIProvider provider = new OpenAICompatibleProvider("http://localhost:1234", "test-model", null);
+        assertTrue(provider.isNotValid(null) || !provider.isNotValid(null),
+                "isNotValid should complete without exception when apiKey is null");
+    }
+
+    @Test
+    void testOpenAICompatibleEmptyApiKey() {
+        BaseAIProvider provider = new OpenAICompatibleProvider("http://localhost:1234", "test-model", Secret.fromString(""));
+        assertTrue(provider.isNotValid(null) || !provider.isNotValid(null),
+                "isNotValid should complete without exception when apiKey is empty");
+    }
+
+    @Test
+    void testOpenAICompatibleValidConfig() {
+        OpenAICompatibleProvider provider = new OpenAICompatibleProvider(
+                "http://localhost:1234", "gateway-model", Secret.fromString("test-key"));
+        assertEquals("http://localhost:1234", provider.getUrl());
+        assertEquals("gateway-model", provider.getModel());
+        assertEquals("test-key", Secret.toString(provider.getApiKey()));
+    }
+
+    @Test
     void testBedrockNullModel() {
         BaseAIProvider provider = new BedrockProvider(null, null, "eu-west-1", null);
         ExplanationException result = assertThrows(ExplanationException.class, () -> provider.explainError("Test error", null));

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/ProxyAwareHttpClientTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/ProxyAwareHttpClientTest.java
@@ -1,0 +1,139 @@
+package io.jenkins.plugins.explain_error.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpMethod;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ProxyAwareHttpClientTest {
+
+    private static final String PROXY_AUTHORIZATION = "Basic dXNlcjpwYXNz"; // user:pass
+
+    private static final class StubHttpClient implements HttpClient {
+
+        final List<HttpRequest> requests = new ArrayList<>();
+
+        @Override
+        public SuccessfulHttpResponse execute(HttpRequest request) {
+            requests.add(request);
+            return SuccessfulHttpResponse.builder()
+                    .statusCode(200)
+                    .headers(Map.of())
+                    .body("{}")
+                    .build();
+        }
+
+        @Override
+        public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener eventListener) {
+            requests.add(request);
+        }
+    }
+
+    private static final class StubHttpClientBuilder implements HttpClientBuilder {
+
+        private final HttpClient httpClient;
+
+        StubHttpClientBuilder(HttpClient httpClient) {
+            this.httpClient = httpClient;
+        }
+
+        @Override
+        public Duration connectTimeout() {
+            return Duration.ofSeconds(10);
+        }
+
+        @Override
+        public HttpClientBuilder connectTimeout(Duration connectTimeout) {
+            return this;
+        }
+
+        @Override
+        public Duration readTimeout() {
+            return Duration.ofSeconds(60);
+        }
+
+        @Override
+        public HttpClientBuilder readTimeout(Duration readTimeout) {
+            return this;
+        }
+
+        @Override
+        public HttpClient build() {
+            return httpClient;
+        }
+    }
+
+    @Test
+    void addsProxyAuthorizationHeaderToRegularRequests() {
+        StubHttpClient delegate = new StubHttpClient();
+        HttpClient client = new ProxyAwareHttpClient(delegate, PROXY_AUTHORIZATION);
+
+        HttpRequest request = sampleRequest();
+        client.execute(request);
+
+        assertEquals(1, delegate.requests.size());
+        assertEquals(List.of(PROXY_AUTHORIZATION), delegate.requests.get(0).headers().get("Proxy-Authorization"));
+        assertEquals(List.of("Bearer secret"), delegate.requests.get(0).headers().get("Authorization"));
+    }
+
+    @Test
+    void addsProxyAuthorizationHeaderToStreamingRequests() {
+        StubHttpClient delegate = new StubHttpClient();
+        HttpClient client = new ProxyAwareHttpClient(delegate, PROXY_AUTHORIZATION);
+
+        client.execute(sampleRequest(), (inputStream, listener) -> {}, error -> {});
+
+        assertEquals(1, delegate.requests.size());
+        assertEquals(List.of(PROXY_AUTHORIZATION), delegate.requests.get(0).headers().get("Proxy-Authorization"));
+    }
+
+    @Test
+    void doesNotMutateOriginalRequest() {
+        StubHttpClient delegate = new StubHttpClient();
+        HttpClient client = new ProxyAwareHttpClient(delegate, PROXY_AUTHORIZATION);
+
+        HttpRequest request = sampleRequest();
+        client.execute(request);
+
+        assertTrue(request.headers().get("Proxy-Authorization") == null);
+    }
+
+    @Test
+    void returnsPlainDelegateWhenNoProxyCredentialsConfigured() {
+        StubHttpClient delegate = new StubHttpClient();
+        HttpClientBuilder builder = new ProxyAwareHttpClientBuilder(new StubHttpClientBuilder(delegate), null);
+
+        assertSame(delegate, builder.build());
+    }
+
+    @Test
+    void wrapsDelegateWhenProxyCredentialsConfigured() {
+        StubHttpClient delegate = new StubHttpClient();
+        HttpClientBuilder builder =
+                new ProxyAwareHttpClientBuilder(new StubHttpClientBuilder(delegate), PROXY_AUTHORIZATION);
+
+        assertTrue(builder.build() instanceof ProxyAwareHttpClient);
+    }
+
+    private static HttpRequest sampleRequest() {
+        return HttpRequest.builder()
+                .method(HttpMethod.POST)
+                .url("https://example.com/chat/completions")
+                .addHeader("Authorization", "Bearer secret")
+                .addHeader("Content-Type", "application/json")
+                .body("{}")
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a generic **OpenAI Compatible** provider for OpenAI-compatible AI gateways such as LiteLLM, OpenWebUI, self-hosted proxies, and enterprise API gateways.

### What this PR does

- **New provider `OpenAICompatibleProvider`** (`@Symbol("openaiCompatible")`)
  - Custom base URL (`/chat/completions` appended automatically), free-text model name (gateway-defined models like `azure/gpt-4o`)
  - API key is **optional** and sent as a standard `Authorization: Bearer` header, enabling unauthenticated local gateways/proxies
  - Clear authentication error messages for 401/403 responses from gateways (including non-standard bodies), instead of the raw, unhelpful response body
- **Redirect support**: `BaseAIProvider.newJenkinsHttpClientBuilder()` now sets `followRedirects(NORMAL)`, matching Jenkins core's own HttpClient behaviour. HTTP redirects (e.g. http -> https upgrades behind load balancers) previously failed for all providers
- **Tests**: 12 new tests covering custom endpoint + Bearer header, omitted Authorization header without a key, end-to-end 307 redirect following, 401 error messaging, FixAssistant, and validation cases
- **Docs**: README (feature list, config table, YAML example, provider section) and `docs/auto-fix.md` provider list updated

### Notes

- No changes to `GlobalConfigurationImpl` — the provider is discovered via the existing `ExtensionPoint` mechanism
- No new dependencies; reuses the already-bundled `langchain4j-open-ai`
- No regression risk for existing providers: the redirect change only affects 3xx responses, which previously always failed

### Verification

- `mvn verify`: 460 tests pass, BUILD SUCCESS
- `make lint`: no new issues

closes #212
