### PR TITLE
feat: add connection diagnostics to failed provider configuration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ Requests from the RunListener are tracked under the `run_listener` entry point i
 |API key not set	| Add your key in Jenkins global config |
 |Auth or rate limit error| Check key validity, quota, and provider plan. See [AI Provider Call Quotas](docs/usage-quota.md) |
 |Button not visible	| Ensure Jenkins version ≥ 2.528.3, restart Jenkins after installation |
+|Test Configuration fails| The error now includes a **connection diagnostics report** (proxy decision, DNS, TCP, HTTP probe). Read it bottom-up to find the failing layer, and paste it when reporting issues |
 
 Enable debug logs:
 

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/AnthropicProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/AnthropicProvider.java
@@ -210,6 +210,13 @@ public class AnthropicProvider extends BaseAIProvider {
         return !hasAnyAuth || modelName == null;
     }
 
+    @Override
+    public String getEffectiveEndpointForDiagnostics() {
+        String configured = Util.fixEmptyAndTrim(getUrl());
+        // langchain4j's Anthropic default base URL when none is configured.
+        return configured != null ? configured : "https://api.anthropic.com/v1/";
+    }
+
     @Extension
     @Symbol("anthropic")
     public static class DescriptorImpl extends BaseProviderDescriptor {
@@ -273,7 +280,7 @@ public class AnthropicProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/AzureOpenAIProvider.java
@@ -716,7 +716,7 @@ public class AzureOpenAIProvider extends BaseAIProvider {
                 provider.testConfiguration();
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/BaseAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/BaseAIProvider.java
@@ -26,6 +26,7 @@ import dev.langchain4j.service.V;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.ProxyConfiguration;
 import hudson.ExtensionPoint;
+import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.model.Item;
@@ -324,6 +325,11 @@ public abstract class BaseAIProvider extends AbstractDescribableImpl<BaseAIProvi
      */
     @CheckForNull
     protected final String getProxyAuthorizationHeader() {
+        return proxyAuthorizationHeaderOrNull();
+    }
+
+    @CheckForNull
+    static String proxyAuthorizationHeaderOrNull() {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         ProxyConfiguration proxyConfiguration = jenkins != null ? jenkins.getProxy() : null;
         // Require a proxy host as well as a user name: newJenkinsHttpClientBuilder()
@@ -338,6 +344,19 @@ public abstract class BaseAIProvider extends AbstractDescribableImpl<BaseAIProvi
         String password = secretPassword == null ? "" : Secret.toString(secretPassword);
         String credentials = proxyConfiguration.getUserName() + ":" + password;
         return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * The endpoint URL this provider would call, used only to run connection
+     * diagnostics when a configuration test fails. Providers with a fixed or
+     * derivable default endpoint should override this to return it when no
+     * explicit URL is configured.
+     *
+     * @return the effective endpoint URL, or {@code null} when unknown
+     */
+    @CheckForNull
+    public String getEffectiveEndpointForDiagnostics() {
+        return Util.fixEmptyAndTrim(url);
     }
 
     protected final HttpClientBuilder newLangChainHttpClientBuilder() {
@@ -366,6 +385,24 @@ public abstract class BaseAIProvider extends AbstractDescribableImpl<BaseAIProvi
             } else {
                 Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             }
+        }
+
+        /**
+         * Builds the failure response for a "Test Configuration" call:
+         * the provider error plus a layer-by-layer connection diagnostics
+         * report (proxy decision, DNS, TCP, HTTP probe, error cause chain)
+         * so admins can see where the connection breaks.
+         *
+         * @param provider the provider instance the test was run against
+         * @param failure  the exception the test failed with
+         * @return a form validation error carrying the diagnostics report
+         */
+        protected final FormValidation testConfigurationFailed(BaseAIProvider provider, Exception failure) {
+            String report = ConnectionDiagnostics.run(provider.getEffectiveEndpointForDiagnostics(), failure);
+            return FormValidation.errorWithMarkup("<b>Configuration test failed:</b> "
+                    + Util.escape(String.valueOf(failure.getMessage()))
+                    + "<pre style=\"white-space:pre-wrap;margin-top:6px;user-select:all\">"
+                    + Util.escape(report) + "</pre>");
         }
 
         @POST

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/BedrockProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/BedrockProvider.java
@@ -58,6 +58,16 @@ public class BedrockProvider extends BaseAIProvider {
         return region;
     }
 
+    @Override
+    public String getEffectiveEndpointForDiagnostics() {
+        String configured = Util.fixEmptyAndTrim(getUrl());
+        if (configured != null) {
+            // A private VPC endpoint may be configured as a bare hostname.
+            return configured.contains("://") ? configured : "https://" + configured;
+        }
+        return region != null ? "https://bedrock-runtime." + region + ".amazonaws.com" : null;
+    }
+
     public String getRoleArn() {
         return roleArn;
     }
@@ -282,7 +292,7 @@ public class BedrockProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! AWS Bedrock connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
 

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/ConnectionDiagnostics.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/ConnectionDiagnostics.java
@@ -1,0 +1,301 @@
+package io.jenkins.plugins.explain_error.provider;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.ProxyConfiguration;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.net.ssl.SSLException;
+import jenkins.model.Jenkins;
+
+/**
+ * Produces a plain-text connectivity report for a failed "Test Configuration"
+ * call, so that admins can see <em>why</em> a provider endpoint cannot be
+ * reached instead of a bare error message.
+ * <p>
+ * The report walks the connection layers one by one — URL syntax, Jenkins
+ * proxy applicability (including {@code noProxyHost} exclusions), local DNS
+ * resolution, TCP connect, and a full-stack HTTP probe that uses the same
+ * proxy and redirect configuration as the real provider calls — and finishes
+ * with the unwrapped error-cause chain.
+ * <p>
+ * Diagnostics run only on demand from the configuration form (behind the same
+ * permission check as the test itself), never during builds. Each probe is
+ * individually bounded by a timeout and guarded so this class can never throw.
+ * Proxy credentials are reported as configured/not configured, never printed.
+ */
+final class ConnectionDiagnostics {
+
+    private static final int TCP_TIMEOUT_MS = 5_000;
+    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(8);
+    private static final int BODY_EXCERPT_CHARS = 200;
+    private static final int MAX_CAUSE_CHAIN = 6;
+
+    private ConnectionDiagnostics() {
+    }
+
+    /**
+     * Builds the report.
+     *
+     * @param endpointUrl the endpoint the provider would call, or {@code null}
+     *                    when it cannot be determined
+     * @param failure     the exception the configuration test failed with
+     * @return a multi-line plain-text report, never {@code null}
+     */
+    static String run(@CheckForNull String endpointUrl, @CheckForNull Throwable failure) {
+        StringBuilder out = new StringBuilder();
+        try {
+            out.append("--- Connection diagnostics ---\n");
+            appendErrorChain(out, failure);
+
+            URI uri = parseEndpoint(out, endpointUrl);
+            if (uri != null) {
+                Proxy proxy = appendProxyDecision(out, uri.getHost());
+                boolean dnsOk = appendDnsProbe(out, uri.getHost(), proxy);
+                appendTcpProbe(out, uri, proxy, dnsOk);
+                appendHttpProbe(out, uri);
+            }
+
+            appendJenkinsProxySummary(out);
+        } catch (RuntimeException e) {
+            // Diagnostics must never break the error response they decorate.
+            out.append("(diagnostics aborted: ").append(e).append(")\n");
+        }
+        return out.toString();
+    }
+
+    private static void appendErrorChain(StringBuilder out, @CheckForNull Throwable failure) {
+        if (failure == null) {
+            return;
+        }
+        List<String> chain = new ArrayList<>();
+        Throwable current = failure;
+        String previousDescription = null;
+        while (current != null && chain.size() < MAX_CAUSE_CHAIN) {
+            String description = current.getClass().getSimpleName() + ": " + summarize(current.getMessage());
+            if (!description.equals(previousDescription)) {
+                chain.add(description);
+                previousDescription = description;
+            }
+            current = current.getCause();
+        }
+        out.append("Error chain: ").append(String.join("\n  <- ", chain)).append('\n');
+    }
+
+    @CheckForNull
+    private static URI parseEndpoint(StringBuilder out, @CheckForNull String endpointUrl) {
+        if (endpointUrl == null || endpointUrl.isBlank()) {
+            out.append("Endpoint: not determined for this provider; network probes skipped.\n");
+            return null;
+        }
+        try {
+            URI uri = URI.create(endpointUrl.trim());
+            String scheme = uri.getScheme();
+            if (uri.getHost() == null || scheme == null
+                    || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+                out.append("Endpoint: ").append(endpointUrl)
+                        .append(" — not a usable http(s) URL; network probes skipped.\n");
+                return null;
+            }
+            out.append("Endpoint: ").append(uri).append('\n');
+            return uri;
+        } catch (IllegalArgumentException e) {
+            out.append("Endpoint: ").append(endpointUrl).append(" — invalid URL: ")
+                    .append(summarize(e.getMessage())).append('\n');
+            return null;
+        }
+    }
+
+    /**
+     * Reports which proxy Jenkins would use for the endpoint host, honouring
+     * {@code noProxyHost} exclusions.
+     *
+     * @return the proxy to use, or {@link Proxy#NO_PROXY} for a direct connection
+     */
+    private static Proxy appendProxyDecision(StringBuilder out, String host) {
+        ProxyConfiguration proxyConfiguration = jenkinsProxy();
+        if (proxyConfiguration == null || proxyConfiguration.getName() == null) {
+            out.append("Proxy: none configured; connecting directly.\n");
+            return Proxy.NO_PROXY;
+        }
+        Proxy proxy = proxyConfiguration.createProxy(host);
+        if (proxy == Proxy.NO_PROXY || proxy.type() == Proxy.Type.DIRECT) {
+            out.append("Proxy: configured (").append(proxyConfiguration.getName()).append(':')
+                    .append(proxyConfiguration.getPort())
+                    .append(") but this host matches noProxyHost — connecting directly.\n");
+            return Proxy.NO_PROXY;
+        }
+        out.append("Proxy: via ").append(proxyConfiguration.getName()).append(':')
+                .append(proxyConfiguration.getPort())
+                .append(proxyConfiguration.getUserName() != null
+                        ? " (credentials configured)" : " (no credentials)")
+                .append('\n');
+        return proxy;
+    }
+
+    private static boolean appendDnsProbe(StringBuilder out, String host, Proxy proxy) {
+        long start = System.nanoTime();
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            String shown = java.util.Arrays.stream(addresses).limit(3)
+                    .map(InetAddress::getHostAddress)
+                    .collect(Collectors.joining(", "));
+            out.append("DNS: ").append(host).append(" -> ").append(shown)
+                    .append(addresses.length > 3 ? ", ..." : "")
+                    .append(" (").append(elapsedMs(start)).append(" ms)\n");
+            return true;
+        } catch (Exception e) {
+            out.append("DNS: FAILED to resolve ").append(host).append(" locally: ")
+                    .append(summarize(e.getMessage()));
+            if (proxy != Proxy.NO_PROXY) {
+                out.append(" — may still work: the proxy resolves names for tunneled connections");
+            }
+            out.append('\n');
+            return false;
+        }
+    }
+
+    private static void appendTcpProbe(StringBuilder out, URI uri, Proxy proxy, boolean dnsOk) {
+        String targetHost;
+        int targetPort;
+        String label;
+        if (proxy != Proxy.NO_PROXY && proxy.address() instanceof InetSocketAddress proxyAddress) {
+            targetHost = proxyAddress.getHostString();
+            targetPort = proxyAddress.getPort();
+            label = "proxy " + targetHost + ":" + targetPort;
+        } else {
+            if (!dnsOk) {
+                out.append("TCP connect: skipped (DNS resolution failed).\n");
+                return;
+            }
+            targetHost = uri.getHost();
+            targetPort = uri.getPort() != -1 ? uri.getPort()
+                    : ("https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80);
+            label = targetHost + ":" + targetPort;
+        }
+
+        long start = System.nanoTime();
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(targetHost, targetPort), TCP_TIMEOUT_MS);
+            out.append("TCP connect: OK to ").append(label)
+                    .append(" (").append(elapsedMs(start)).append(" ms)\n");
+        } catch (Exception e) {
+            out.append("TCP connect: FAILED to ").append(label).append(" after ")
+                    .append(elapsedMs(start)).append(" ms: ")
+                    .append(summarize(e.getMessage())).append('\n');
+        }
+    }
+
+    /**
+     * Full-stack probe with the same proxy, credentials and redirect settings
+     * the real provider calls use. A response of any HTTP status counts as
+     * reachable — 401/404 from the base URL still proves DNS, TCP, TLS and
+     * proxy traversal all work.
+     */
+    private static void appendHttpProbe(StringBuilder out, URI uri) {
+        long start = System.nanoTime();
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(5))
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .proxy(diagnosticsProxySelector())
+                    .build();
+            HttpRequest.Builder request = HttpRequest.newBuilder(uri)
+                    .timeout(HTTP_TIMEOUT)
+                    .GET();
+            String proxyAuthorization = BaseAIProvider.proxyAuthorizationHeaderOrNull();
+            if (proxyAuthorization != null) {
+                request.header("Proxy-Authorization", proxyAuthorization);
+            }
+            HttpResponse<String> response = client.send(request.build(), HttpResponse.BodyHandlers.ofString());
+            out.append("HTTP probe: GET ").append(uri).append(" -> HTTP ").append(response.statusCode())
+                    .append(" (").append(elapsedMs(start)).append(" ms)");
+            if (response.statusCode() == HttpURLConnection.HTTP_UNAUTHORIZED
+                    || response.statusCode() == HttpURLConnection.HTTP_FORBIDDEN) {
+                out.append(" — endpoint reachable; check the API key / authentication settings");
+            }
+            out.append('\n');
+            String excerpt = summarize(response.body());
+            if (!excerpt.isEmpty()) {
+                out.append("HTTP probe response excerpt: ").append(excerpt).append('\n');
+            }
+        } catch (SSLException e) {
+            out.append("HTTP probe: TLS handshake FAILED after ").append(elapsedMs(start))
+                    .append(" ms: ").append(summarize(e.getMessage()))
+                    .append(" — check certificates/truststore on the controller\n");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            out.append("HTTP probe: interrupted\n");
+        } catch (Exception e) {
+            out.append("HTTP probe: FAILED after ").append(elapsedMs(start)).append(" ms: ")
+                    .append(e.getClass().getSimpleName()).append(": ")
+                    .append(summarize(e.getMessage())).append('\n');
+        }
+    }
+
+    private static void appendJenkinsProxySummary(StringBuilder out) {
+        ProxyConfiguration proxyConfiguration = jenkinsProxy();
+        if (proxyConfiguration == null || proxyConfiguration.getName() == null) {
+            return;
+        }
+        out.append("Jenkins proxy settings: host=").append(proxyConfiguration.getName())
+                .append(" port=").append(proxyConfiguration.getPort())
+                .append(" credentials=").append(proxyConfiguration.getUserName() != null ? "configured" : "none")
+                .append(" noProxyHost=").append(nullToNone(proxyConfiguration.getNoProxyHost()))
+                .append('\n');
+    }
+
+    private static ProxySelector diagnosticsProxySelector() {
+        return new ProxySelector() {
+            @Override
+            public List<Proxy> select(URI uri) {
+                ProxyConfiguration proxyConfiguration = jenkinsProxy();
+                if (proxyConfiguration != null && proxyConfiguration.getName() != null && uri.getHost() != null) {
+                    return List.of(proxyConfiguration.createProxy(uri.getHost()));
+                }
+                return List.of(Proxy.NO_PROXY);
+            }
+
+            @Override
+            public void connectFailed(URI uri, SocketAddress sa, java.io.IOException ioe) {
+                // Reported by the probe's own exception handling.
+            }
+        };
+    }
+
+    @CheckForNull
+    private static ProxyConfiguration jenkinsProxy() {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        return jenkins != null ? jenkins.getProxy() : null;
+    }
+
+    private static String summarize(@CheckForNull String text) {
+        if (text == null) {
+            return "";
+        }
+        String flattened = text.replaceAll("\\s+", " ").trim();
+        return flattened.length() > BODY_EXCERPT_CHARS
+                ? flattened.substring(0, BODY_EXCERPT_CHARS) + "..."
+                : flattened;
+    }
+
+    private static long elapsedMs(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000L;
+    }
+
+    private static String nullToNone(@CheckForNull String value) {
+        return value == null || value.isBlank() ? "(none)" : value.replaceAll("\\s+", " ");
+    }
+}

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/ConnectionDiagnostics.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/ConnectionDiagnostics.java
@@ -65,7 +65,7 @@ final class ConnectionDiagnostics {
                 Proxy proxy = appendProxyDecision(out, uri.getHost());
                 boolean dnsOk = appendDnsProbe(out, uri.getHost(), proxy);
                 appendTcpProbe(out, uri, proxy, dnsOk);
-                appendHttpProbe(out, uri);
+                appendHttpProbe(out, uri, proxy);
             }
 
             appendJenkinsProxySummary(out);
@@ -204,7 +204,7 @@ final class ConnectionDiagnostics {
      * reachable — 401/404 from the base URL still proves DNS, TCP, TLS and
      * proxy traversal all work.
      */
-    private static void appendHttpProbe(StringBuilder out, URI uri) {
+    private static void appendHttpProbe(StringBuilder out, URI uri, Proxy proxy) {
         long start = System.nanoTime();
         try {
             HttpClient client = HttpClient.newBuilder()
@@ -215,9 +215,14 @@ final class ConnectionDiagnostics {
             HttpRequest.Builder request = HttpRequest.newBuilder(uri)
                     .timeout(HTTP_TIMEOUT)
                     .GET();
-            String proxyAuthorization = BaseAIProvider.proxyAuthorizationHeaderOrNull();
-            if (proxyAuthorization != null) {
-                request.header("Proxy-Authorization", proxyAuthorization);
+            // Only send proxy credentials when this host actually goes through
+            // the proxy — on a direct connection (no proxy, or noProxyHost
+            // exclusion) the header would leak them to the endpoint itself.
+            if (proxy != Proxy.NO_PROXY) {
+                String proxyAuthorization = BaseAIProvider.proxyAuthorizationHeaderOrNull();
+                if (proxyAuthorization != null) {
+                    request.header("Proxy-Authorization", proxyAuthorization);
+                }
             }
             HttpResponse<String> response = client.send(request.build(), HttpResponse.BodyHandlers.ofString());
             out.append("HTTP probe: GET ").append(uri).append(" -> HTTP ").append(response.statusCode())

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/CustomOktaAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/CustomOktaAIProvider.java
@@ -622,7 +622,7 @@ public class CustomOktaAIProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/DeepSeekProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/DeepSeekProvider.java
@@ -92,6 +92,11 @@ public class DeepSeekProvider extends BaseAIProvider {
         return trimmedUrl != null ? trimmedUrl : DEFAULT_URL;
     }
 
+    @Override
+    public String getEffectiveEndpointForDiagnostics() {
+        return resolveUrl(getUrl());
+    }
+
     @Extension
     @Symbol("deepseek")
     public static class DescriptorImpl extends BaseProviderDescriptor {
@@ -143,7 +148,7 @@ public class DeepSeekProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/GeminiProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/GeminiProvider.java
@@ -82,6 +82,13 @@ public class GeminiProvider extends BaseAIProvider {
                 Util.fixEmptyAndTrim(getModel()) == null;
     }
 
+    @Override
+    public String getEffectiveEndpointForDiagnostics() {
+        String configured = Util.fixEmptyAndTrim(getUrl());
+        // langchain4j's Gemini default base URL when none is configured.
+        return configured != null ? configured : "https://generativelanguage.googleapis.com";
+    }
+
     @Extension
     @Symbol("gemini")
     public static class DescriptorImpl extends BaseProviderDescriptor {
@@ -112,7 +119,7 @@ public class GeminiProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
 

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/LangGraphProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/LangGraphProvider.java
@@ -365,7 +365,7 @@ public class LangGraphProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! LangGraph Platform connection is working.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/MicrosoftFoundryProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/MicrosoftFoundryProvider.java
@@ -157,7 +157,7 @@ public class MicrosoftFoundryProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/OllamaProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/OllamaProvider.java
@@ -128,7 +128,7 @@ public class OllamaProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAICompatibleProvider.java
@@ -209,7 +209,7 @@ public class OpenAICompatibleProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAIProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/OpenAIProvider.java
@@ -87,6 +87,13 @@ public class OpenAIProvider extends BaseAIProvider {
                 Util.fixEmptyAndTrim(getModel()) == null;
     }
 
+    @Override
+    public String getEffectiveEndpointForDiagnostics() {
+        String configured = Util.fixEmptyAndTrim(getUrl());
+        // langchain4j's OpenAI default base URL when none is configured.
+        return configured != null ? configured : "https://api.openai.com/v1";
+    }
+
     @Extension
     @Symbol("openai")
     public static class DescriptorImpl extends BaseProviderDescriptor {
@@ -141,7 +148,7 @@ public class OpenAIProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/explain_error/provider/QwenProvider.java
+++ b/src/main/java/io/jenkins/plugins/explain_error/provider/QwenProvider.java
@@ -178,6 +178,11 @@ public class QwenProvider extends BaseAIProvider {
         return trimmedUrl != null ? trimmedUrl : DEFAULT_URL;
     }
 
+    @Override
+    public String getEffectiveEndpointForDiagnostics() {
+        return resolveUrl(getUrl());
+    }
+
     @Extension
     @Symbol("qwen")
     public static class DescriptorImpl extends BaseProviderDescriptor {
@@ -237,7 +242,7 @@ public class QwenProvider extends BaseAIProvider {
                 provider.explainError("Send 'Configuration test successful' to me.", null);
                 return FormValidation.ok("Configuration test successful! API connection is working properly.");
             } catch (ExplanationException e) {
-                return FormValidation.error("Configuration test failed: " + e.getMessage(), e);
+                return testConfigurationFailed(provider, e);
             }
         }
     }

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/ConnectionDiagnosticsTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/ConnectionDiagnosticsTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.explain_error.provider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.sun.net.httpserver.HttpServer;
@@ -13,12 +14,24 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
+/**
+ * Every test declares the {@link JenkinsRule} parameter even when it never
+ * reads it: {@code JenkinsExtension} boots Jenkins from {@code resolveParameter}
+ * (it has no {@code BeforeEachCallback}), so dropping the parameter would leave
+ * {@code Jenkins.getInstanceOrNull()} null and silently exercise a different
+ * code path than the one these tests cover.
+ */
 @WithJenkins
 class ConnectionDiagnosticsTest {
+
+    private static final String PROXY_USER = "proxy-user";
+    private static final String PROXY_PASSWORD = "proxy-pass";
 
     @Test
     void reachableEndpointReportsAllLayers(JenkinsRule jenkins) throws Exception {
@@ -83,7 +96,7 @@ class ConnectionDiagnosticsTest {
     @Test
     void proxiedHostReportsProxyDecision(JenkinsRule jenkins) {
         jenkins.jenkins.proxy = new ProxyConfiguration(
-                "proxy.example.invalid", 3128, "proxy-user", "proxy-pass", "excluded.example.com");
+                "proxy.example.invalid", 3128, PROXY_USER, PROXY_PASSWORD, "excluded.example.com");
 
         String report = ConnectionDiagnostics.run("https://api.example.invalid",
                 new RuntimeException("boom"));
@@ -91,7 +104,7 @@ class ConnectionDiagnosticsTest {
         assertTrue(report.contains("Proxy: via proxy.example.invalid:3128 (credentials configured)"), report);
         assertTrue(report.contains("Jenkins proxy settings: host=proxy.example.invalid port=3128"
                 + " credentials=configured noProxyHost=excluded.example.com"), report);
-        assertFalse(report.contains("proxy-pass"), "credentials must never be printed: " + report);
+        assertFalse(report.contains(PROXY_PASSWORD), "credentials must never be printed: " + report);
     }
 
     @Test
@@ -103,6 +116,70 @@ class ConnectionDiagnosticsTest {
                 new RuntimeException("boom"));
 
         assertTrue(report.contains("matches noProxyHost — connecting directly"), report);
+    }
+
+    @Test
+    void directConnectionNeverSendsProxyCredentials(JenkinsRule jenkins) throws Exception {
+        AtomicReference<String> proxyAuthorization = new AtomicReference<>();
+        HttpServer server = startCapturingServer(proxyAuthorization);
+        try {
+            // Proxy credentials are configured, but this host is excluded from
+            // the proxy, so the probe connects directly and must not leak them.
+            jenkins.jenkins.proxy = new ProxyConfiguration(
+                    "proxy.example.invalid", 3128, PROXY_USER, PROXY_PASSWORD, "127.0.0.1");
+
+            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/v1";
+            String report = ConnectionDiagnostics.run(url, new RuntimeException("boom"));
+
+            assertTrue(report.contains("matches noProxyHost — connecting directly"), report);
+            assertTrue(report.contains("-> HTTP 200"), report);
+            assertNull(proxyAuthorization.get(),
+                    "Proxy credentials must not be sent on a direct connection");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void proxiedConnectionSendsProxyCredentials(JenkinsRule jenkins) throws Exception {
+        AtomicReference<String> proxyAuthorization = new AtomicReference<>();
+        // Stands in for the proxy: a plain http request through a proxy is sent
+        // to the proxy itself, so this server sees the probe and its headers.
+        HttpServer proxyServer = startCapturingServer(proxyAuthorization);
+        try {
+            jenkins.jenkins.proxy = new ProxyConfiguration(
+                    "127.0.0.1", proxyServer.getAddress().getPort(), PROXY_USER, PROXY_PASSWORD, null);
+
+            String report = ConnectionDiagnostics.run("http://target.example.invalid/v1",
+                    new RuntimeException("boom"));
+
+            assertTrue(report.contains("-> HTTP 200"), report);
+            String expected = "Basic " + Base64.getEncoder().encodeToString(
+                    (PROXY_USER + ":" + PROXY_PASSWORD).getBytes(StandardCharsets.UTF_8));
+            assertEquals(expected, proxyAuthorization.get(),
+                    "Proxy credentials must be sent when the host goes through the proxy");
+            assertFalse(report.contains(PROXY_PASSWORD), "credentials must never be printed: " + report);
+        } finally {
+            proxyServer.stop(0);
+        }
+    }
+
+    /**
+     * Starts a local server that records the {@code Proxy-Authorization} header
+     * of the first request it receives and answers 200.
+     */
+    private static HttpServer startCapturingServer(AtomicReference<String> proxyAuthorization) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            proxyAuthorization.compareAndSet(null, exchange.getRequestHeaders().getFirst("Proxy-Authorization"));
+            byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        return server;
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/explain_error/provider/ConnectionDiagnosticsTest.java
+++ b/src/test/java/io/jenkins/plugins/explain_error/provider/ConnectionDiagnosticsTest.java
@@ -1,0 +1,126 @@
+package io.jenkins.plugins.explain_error.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import hudson.ProxyConfiguration;
+import hudson.util.FormValidation;
+import hudson.util.Secret;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class ConnectionDiagnosticsTest {
+
+    @Test
+    void reachableEndpointReportsAllLayers(JenkinsRule jenkins) throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            byte[] body = "{\"error\":\"unauthorized\"}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(401, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        try {
+            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/v1";
+            String report = ConnectionDiagnostics.run(url, new RuntimeException("boom"));
+
+            assertTrue(report.contains("Endpoint: " + url), report);
+            assertTrue(report.contains("Proxy: none configured"), report);
+            assertTrue(report.contains("DNS: 127.0.0.1 ->"), report);
+            assertTrue(report.contains("TCP connect: OK"), report);
+            assertTrue(report.contains("-> HTTP 401"), report);
+            assertTrue(report.contains("check the API key / authentication settings"), report);
+            assertTrue(report.contains("unauthorized"), report);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void closedPortReportsTcpFailure(JenkinsRule jenkins) throws Exception {
+        int closedPort;
+        try (ServerSocket socket = new ServerSocket(0)) {
+            closedPort = socket.getLocalPort();
+        }
+        String report = ConnectionDiagnostics.run("http://127.0.0.1:" + closedPort,
+                new RuntimeException("boom"));
+
+        assertTrue(report.contains("TCP connect: FAILED"), report);
+        assertTrue(report.contains("HTTP probe: FAILED"), report);
+    }
+
+    @Test
+    void unknownHostReportsDnsFailure(JenkinsRule jenkins) {
+        String report = ConnectionDiagnostics.run("https://no-such-host.invalid",
+                new RuntimeException("boom"));
+
+        assertTrue(report.contains("DNS: FAILED to resolve no-such-host.invalid"), report);
+        assertTrue(report.contains("TCP connect: skipped (DNS resolution failed)"), report);
+    }
+
+    @Test
+    void missingEndpointSkipsProbesButKeepsErrorChain(JenkinsRule jenkins) {
+        String report = ConnectionDiagnostics.run(null,
+                new IllegalStateException("outer", new IOException("root cause")));
+
+        assertTrue(report.contains("Endpoint: not determined"), report);
+        assertTrue(report.contains("IllegalStateException: outer"), report);
+        assertTrue(report.contains("IOException: root cause"), report);
+        assertFalse(report.contains("TCP connect"), report);
+    }
+
+    @Test
+    void proxiedHostReportsProxyDecision(JenkinsRule jenkins) {
+        jenkins.jenkins.proxy = new ProxyConfiguration(
+                "proxy.example.invalid", 3128, "proxy-user", "proxy-pass", "excluded.example.com");
+
+        String report = ConnectionDiagnostics.run("https://api.example.invalid",
+                new RuntimeException("boom"));
+
+        assertTrue(report.contains("Proxy: via proxy.example.invalid:3128 (credentials configured)"), report);
+        assertTrue(report.contains("Jenkins proxy settings: host=proxy.example.invalid port=3128"
+                + " credentials=configured noProxyHost=excluded.example.com"), report);
+        assertFalse(report.contains("proxy-pass"), "credentials must never be printed: " + report);
+    }
+
+    @Test
+    void noProxyHostExclusionReportsDirectConnection(JenkinsRule jenkins) {
+        jenkins.jenkins.proxy = new ProxyConfiguration(
+                "proxy.example.invalid", 3128, null, null, "excluded.example.com");
+
+        String report = ConnectionDiagnostics.run("https://excluded.example.com",
+                new RuntimeException("boom"));
+
+        assertTrue(report.contains("matches noProxyHost — connecting directly"), report);
+    }
+
+    @Test
+    void testConfigurationFailureCarriesDiagnosticsReport(JenkinsRule jenkins) throws Exception {
+        int closedPort;
+        try (ServerSocket socket = new ServerSocket(0)) {
+            closedPort = socket.getLocalPort();
+        }
+        OpenAICompatibleProvider.DescriptorImpl descriptor =
+                jenkins.jenkins.getDescriptorByType(OpenAICompatibleProvider.DescriptorImpl.class);
+
+        FormValidation validation = descriptor.doTestConfiguration(null,
+                Secret.fromString("test-key"), "http://127.0.0.1:" + closedPort, "gateway-model");
+
+        assertEquals(FormValidation.Kind.ERROR, validation.kind);
+        String html = validation.renderHtml();
+        assertTrue(html.contains("Connection diagnostics"), html);
+        assertTrue(html.contains("TCP connect: FAILED"), html);
+        assertTrue(html.contains("Error chain:"), html);
+    }
+}


### PR DESCRIPTION
### Description

When **Test Configuration** fails, the form error now carries a layer-by-layer connection diagnostics report instead of a bare provider message, so admins can see *where* the connection breaks and paste the report straight into a bug report:

```
--- Connection diagnostics ---
Error chain: ExplanationException: API request failed <- ConnectException: Connection refused
Endpoint: https://litellm.internal.example/v1
Proxy: via proxy.corp:3128 (credentials configured)
DNS: litellm.internal.example -> 10.1.2.3 (12 ms)
TCP connect: OK to proxy proxy.corp:3128 (45 ms)
HTTP probe: GET https://... -> HTTP 401 (120 ms) — endpoint reachable; check the API key / authentication settings
Jenkins proxy settings: host=proxy.corp port=3128 credentials=configured noProxyHost=(none)
```

Details:

- **Proxy decision**: reports which proxy Jenkins would use for the endpoint, honoring `noProxyHost` exclusions, and whether proxy credentials are configured.
- **DNS**: local resolution with timing; notes that a proxy may still resolve the name when resolution fails locally.
- **TCP connect**: to the endpoint or the proxy, with timing and timeout.
- **HTTP probe**: full-stack GET using the same proxy/redirect/preemptive-credential configuration as real provider calls; any HTTP status (including 401/404) proves DNS, TCP, TLS and proxy traversal work, with an explicit hint for 401/403.
- **Error chain**: unwrapped causes of the original failure.
- All twelve providers route failures through a shared `BaseProviderDescriptor.testConfigurationFailed` helper. Providers with fixed default endpoints (OpenAI, Anthropic, Gemini, DeepSeek, Qwen, Bedrock) report their effective endpoint even when no URL is configured, via a new `getEffectiveEndpointForDiagnostics()` hook.
- Probes run only from the configuration form (behind the existing permission checks), each probe is timeout-bounded and individually guarded so diagnostics can never throw, and proxy credentials are reported as configured/not configured but never printed. All dynamic content in the form validation markup is HTML-escaped.

Motivated by the recurring "test configuration failed and I can't tell why" class of reports: #212 (LiteLLM gateway), #145 (proxy timeouts), #117 (custom endpoint), #193, #172.

### Related Issues

Helps diagnose issues like #212, #145, #117, #193, #172

### Testing done

New `ConnectionDiagnosticsTest` (7 tests): reachable endpoint reports all layers end-to-end against a real local HTTP server; closed port reports TCP failure; unknown host reports DNS failure; missing endpoint skips probes but keeps the error chain; proxied host reports the proxy decision; `noProxyHost` exclusion reports direct connection; and `doTestConfiguration` failure responses carry the diagnostics report. Includes an assertion that proxy credentials never appear in the report.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify below)

Assisted-by: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWtf1QPE3rdCNHAnqzEE3A

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWtf1QPE3rdCNHAnqzEE3A)_